### PR TITLE
fix: make allOf polymorphism compile with kotlinx serialization

### DIFF
--- a/end2end-tests/models-kotlinx/openapi/api.yaml
+++ b/end2end-tests/models-kotlinx/openapi/api.yaml
@@ -184,3 +184,75 @@ components:
       properties:
         one:
           type: string
+    # allOf polymorphism: discriminated parent with allOf child schemas (issue #627)
+    ParentAction:
+      type: object
+      discriminator:
+        propertyName: actionType
+        mapping:
+          CHILD_A: '#/components/schemas/ChildActionA'
+          CHILD_B: '#/components/schemas/ChildActionB'
+      properties:
+        actionType:
+          type: string
+          enum:
+            - CHILD_A
+            - CHILD_B
+        createdBy:
+          type: string
+      required:
+        - actionType
+    ChildActionA:
+      allOf:
+        - $ref: '#/components/schemas/ParentAction'
+        - type: object
+          properties:
+            fieldA:
+              type: string
+    ChildActionB:
+      allOf:
+        - $ref: '#/components/schemas/ParentAction'
+        - type: object
+          properties:
+            fieldB:
+              type: integer
+    # oneOf sealed interface over the allOf children, sharing the parent's discriminator
+    ChildActionsAll:
+      type: array
+      items:
+        oneOf:
+          - $ref: '#/components/schemas/ChildActionA'
+          - $ref: '#/components/schemas/ChildActionB'
+        discriminator:
+          propertyName: actionType
+          mapping:
+            CHILD_A: '#/components/schemas/ChildActionA'
+            CHILD_B: '#/components/schemas/ChildActionB'
+    # allOf polymorphism without an explicit discriminator mapping: values default to the
+    # schema names. Also carries a required inherited property.
+    Vehicle:
+      type: object
+      discriminator:
+        propertyName: vehicleType
+      properties:
+        vehicleType:
+          type: string
+        wheels:
+          type: integer
+      required:
+        - vehicleType
+        - wheels
+    Car:
+      allOf:
+        - $ref: '#/components/schemas/Vehicle'
+        - type: object
+          properties:
+            trunkSize:
+              type: string
+    Truck:
+      allOf:
+        - $ref: '#/components/schemas/Vehicle'
+        - type: object
+          properties:
+            payload:
+              type: integer

--- a/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationAllOfPolymorphicTest.kt
+++ b/end2end-tests/models-kotlinx/src/test/kotlin/com/cjbooms/fabrikt/models/kotlinx/KotlinxSerializationAllOfPolymorphicTest.kt
@@ -1,0 +1,91 @@
+package com.cjbooms.fabrikt.models.kotlinx
+
+import com.example.models.Car
+import com.example.models.ChildActionA
+import com.example.models.ChildActionB
+import com.example.models.ChildActionsAll
+import com.example.models.ParentAction
+import com.example.models.Truck
+import com.example.models.Vehicle
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers allOf-based polymorphism where the parent schema carries the discriminator
+ * (https://github.com/fabrikt-io/fabrikt/issues/627). The child classes must not redeclare the
+ * discriminator property, since kotlinx serialization emits it as the class discriminator.
+ */
+class KotlinxSerializationAllOfPolymorphicTest {
+
+    @Test
+    fun `must serialize ChildActionA with discriminator when serialized as ParentAction`() {
+        val action: ParentAction = ChildActionA(fieldA = "hello")
+        val json = Json.encodeToString(action)
+
+        assertThat(json).isEqualTo("""{"actionType":"CHILD_A","fieldA":"hello"}""")
+    }
+
+    @Test
+    fun `must round-trip a property inherited from the supertype`() {
+        val action: ParentAction = ChildActionA(createdBy = "someone", fieldA = "hello")
+        val json = Json.encodeToString(action)
+
+        assertThat(json).isEqualTo("""{"actionType":"CHILD_A","createdBy":"someone","fieldA":"hello"}""")
+        assertThat(Json.decodeFromString<ParentAction>(json))
+            .isEqualTo(ChildActionA(createdBy = "someone", fieldA = "hello"))
+    }
+
+    @Test
+    fun `must serialize ChildActionB with discriminator when serialized as ParentAction`() {
+        val action: ParentAction = ChildActionB(fieldB = 42)
+        val json = Json.encodeToString(action)
+
+        assertThat(json).isEqualTo("""{"actionType":"CHILD_B","fieldB":42}""")
+    }
+
+    @Test
+    fun `must deserialize ParentAction into ChildActionA`() {
+        val json = """{"actionType":"CHILD_A","fieldA":"hello"}"""
+        val action: ParentAction = Json.decodeFromString(json)
+
+        assertThat(action).isEqualTo(ChildActionA(fieldA = "hello"))
+    }
+
+    @Test
+    fun `must deserialize ParentAction into ChildActionB`() {
+        val json = """{"actionType":"CHILD_B","fieldB":42}"""
+        val action: ParentAction = Json.decodeFromString(json)
+
+        assertThat(action).isEqualTo(ChildActionB(fieldB = 42))
+    }
+
+    @Test
+    fun `must round-trip the children through the oneOf sealed interface`() {
+        val actions: List<ChildActionsAll> = listOf(ChildActionA(fieldA = "hello"), ChildActionB(fieldB = 42))
+        val json = Json.encodeToString(actions)
+
+        assertThat(json)
+            .isEqualTo("""[{"actionType":"CHILD_A","fieldA":"hello"},{"actionType":"CHILD_B","fieldB":42}]""")
+        assertThat(Json.decodeFromString<List<ChildActionsAll>>(json)).isEqualTo(actions)
+    }
+
+    @Test
+    fun `must default the discriminator value to the schema name when the mapping is omitted`() {
+        val vehicle: Vehicle = Car(wheels = 4, trunkSize = "large")
+        val json = Json.encodeToString(vehicle)
+
+        assertThat(json).isEqualTo("""{"vehicleType":"Car","wheels":4,"trunkSize":"large"}""")
+        assertThat(Json.decodeFromString<Vehicle>(json)).isEqualTo(vehicle)
+    }
+
+    @Test
+    fun `must round-trip a required inherited property`() {
+        val json = """{"vehicleType":"Truck","wheels":6,"payload":3500}"""
+        val vehicle: Vehicle = Json.decodeFromString(json)
+
+        assertThat(vehicle).isEqualTo(Truck(wheels = 6, payload = 3500))
+        assertThat(Json.encodeToString(vehicle)).isEqualTo(json)
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/PropertyUtils.kt
@@ -107,6 +107,11 @@ object PropertyUtils {
             when (classSettings.polymorphyType) {
                 ClassSettings.PolymorphyType.SUPER -> {
                     if (this is PropertyInfo.Field && isPolymorphicDiscriminator) {
+                        if (!serializationAnnotations.supportsBackingPropertyForDiscriminator) {
+                            return // the serializer emits the discriminator, so it must not be a class property
+                        }
+                        property.addModifiers(KModifier.ABSTRACT)
+                    } else if (!serializationAnnotations.supportsInheritedBackingProperties) {
                         property.addModifiers(KModifier.ABSTRACT)
                     } else {
                         property.addModifiers(KModifier.OPEN)
@@ -115,11 +120,16 @@ object PropertyUtils {
 
                 ClassSettings.PolymorphyType.SUB -> {
                     if (this is PropertyInfo.Field && isPolymorphicDiscriminator) {
+                        if (!serializationAnnotations.supportsBackingPropertyForDiscriminator) {
+                            return // the serializer emits the discriminator, so it must not be a class property
+                        }
                         property.addModifiers(KModifier.OVERRIDE)
                     } else {
                         if (isInherited) {
                             property.addModifiers(KModifier.OVERRIDE)
-                            classBuilder.addSuperclassConstructorParameter(name)
+                            if (serializationAnnotations.supportsInheritedBackingProperties) {
+                                classBuilder.addSuperclassConstructorParameter(name)
+                            }
                         }
                         serializationAnnotations.addParameter(property, oasKey, isRequired, typeInfo)
                     }
@@ -162,7 +172,7 @@ object PropertyUtils {
                         constructorBuilder.addParameter(constructorParameter.build())
                     }
                 }
-            } else {
+            } else if (!property.modifiers.contains(KModifier.ABSTRACT)) {
                 property.initializer(name)
                 val constructorParameter: ParameterSpec.Builder = ParameterSpec.builder(name, wrappedType)
                 val oasDefault = getDefaultValue(this, parameterizedType)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -20,8 +20,6 @@ import com.cjbooms.fabrikt.generators.TypeFactory.createMutableMapOfMapsStringTo
 import com.cjbooms.fabrikt.generators.TypeFactory.createMutableMapOfStringToType
 import com.cjbooms.fabrikt.generators.TypeFactory.createSet
 import com.cjbooms.fabrikt.generators.ValidationAnnotations
-import com.cjbooms.fabrikt.generators.model.JacksonMetadata.basePolymorphicType
-import com.cjbooms.fabrikt.generators.model.JacksonMetadata.polymorphicSubTypes
 import com.cjbooms.fabrikt.model.SerializationAnnotations
 import com.cjbooms.fabrikt.model.Destinations.modelsPackage
 import com.cjbooms.fabrikt.model.GeneratedType
@@ -820,8 +818,8 @@ class ModelGenerator(
         constructorBuilder: FunSpec.Builder = FunSpec.constructorBuilder(),
     ): TypeSpec.Builder {
         this.addModifiers(KModifier.SEALED)
-            .addAnnotation(basePolymorphicType(discriminator.propertyName))
-            .modifiers.remove(KModifier.DATA)
+        serializationAnnotations.addBasePolymorphicTypeAnnotation(this, discriminator.propertyName)
+        this.modifiers.remove(KModifier.DATA)
 
         for (oneOfSuperInterface in oneOfSuperInterfaces) {
             val interfaceName = ModelNameRegistry.getBySchema(oneOfSuperInterface) ?: ModelNameRegistry.getOrRegister(oneOfSuperInterface)
@@ -848,8 +846,8 @@ class ModelGenerator(
         val maybeEnumDiscriminator = properties
             .firstOrNull { it.name == discriminator.propertyName }?.typeInfo as? KotlinTypeInfo.Enum
 
-        this.addAnnotation(polymorphicSubTypes(mappings, maybeEnumDiscriminator))
-            .addQuarkusReflectionAnnotation()
+        serializationAnnotations.addPolymorphicSubTypesAnnotation(this, mappings, maybeEnumDiscriminator)
+        this.addQuarkusReflectionAnnotation()
             .addMicronautIntrospectedAnnotation()
             .addMicronautReflectionAnnotation()
 
@@ -897,6 +895,13 @@ class ModelGenerator(
         for (oneOfSuperInterface in oneOfSuperInterfaces) {
             val interfaceName = ModelNameRegistry.getBySchema(oneOfSuperInterface) ?: ModelNameRegistry.getOrRegister(oneOfSuperInterface)
             this.addSuperinterface(generatedType(packages.base, interfaceName))
+        }
+
+        val superTypeDiscriminator = superType.schema.discriminator.takeIf { it.propertyName != null }
+            ?: superType.schema.getDiscriminatorForInlinedObjectUnderAllOf()
+        superTypeDiscriminator?.let { discriminator ->
+            val mappingKey = discriminator.mappingKeyForSchemaName(schemaName) ?: schemaName
+            serializationAnnotations.addSubtypeMappingAnnotation(this, mappingKey)
         }
 
         val properties = superType.schema.getDiscriminatorForInlinedObjectUnderAllOf()?.let { discriminator ->

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/JacksonAnnotations.kt
@@ -14,6 +14,7 @@ import com.squareup.kotlinpoet.TypeSpec
 
 object JacksonAnnotations : SerializationAnnotations {
     override val supportsBackingPropertyForDiscriminator = true
+    override val supportsInheritedBackingProperties = true
     override val supportsAdditionalProperties = true
     override fun addIgnore(propertySpecBuilder: PropertySpec.Builder) =
         propertySpecBuilder.addAnnotation(JacksonMetadata.ignore)
@@ -42,8 +43,11 @@ object JacksonAnnotations : SerializationAnnotations {
     override fun addBasePolymorphicTypeAnnotation(typeSpecBuilder: TypeSpec.Builder, propertyName: String) =
         typeSpecBuilder.addAnnotation(basePolymorphicType(propertyName))
 
-    override fun addPolymorphicSubTypesAnnotation(typeSpecBuilder: TypeSpec.Builder, mappings: Map<String, TypeName>) =
-        typeSpecBuilder.addAnnotation(polymorphicSubTypes(mappings, enumDiscriminator = null))
+    override fun addPolymorphicSubTypesAnnotation(
+        typeSpecBuilder: TypeSpec.Builder,
+        mappings: Map<String, TypeName>,
+        enumDiscriminator: KotlinTypeInfo.Enum?,
+    ) = typeSpecBuilder.addAnnotation(polymorphicSubTypes(mappings, enumDiscriminator))
 
     override fun addPolymorphicSubTypeDeductionAnnotation(typeSpecBuilder: TypeSpec.Builder, subTypes: List<TypeName>) =
         typeSpecBuilder

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinxSerializationAnnotations.kt
@@ -23,6 +23,13 @@ object KotlinxSerializationAnnotations : SerializationAnnotations {
     override val supportsBackingPropertyForDiscriminator = false
 
     /**
+     * kotlinx serialization includes superclass backing fields in the subclass serial state,
+     * so a subtype overriding a supertype property with its own backing field would produce a
+     * duplicate serial name. Super type properties must be abstract instead.
+     */
+    override val supportsInheritedBackingProperties = false
+
+    /**
      * Supporting "additionalProperties: true" for kotlinx serialization requires additional
      * research and work due to Any type in the map (val properties: MutableMap<String, Any?>)
      *
@@ -98,8 +105,11 @@ object KotlinxSerializationAnnotations : SerializationAnnotations {
             typeSpecBuilder.addAnnotation(experimentalSerializationApiAnnotation)
         } else typeSpecBuilder
 
-    override fun addPolymorphicSubTypesAnnotation(typeSpecBuilder: TypeSpec.Builder, mappings: Map<String, TypeName>) =
-        typeSpecBuilder // not applicable
+    override fun addPolymorphicSubTypesAnnotation(
+        typeSpecBuilder: TypeSpec.Builder,
+        mappings: Map<String, TypeName>,
+        enumDiscriminator: KotlinTypeInfo.Enum?,
+    ) = typeSpecBuilder // not applicable — subtypes carry a @SerialName mapping instead
 
     override fun addPolymorphicSubTypeDeductionAnnotation(typeSpecBuilder: TypeSpec.Builder, subTypes: List<TypeName>) =
         typeSpecBuilder // not applicable — kotlinx requires a class discriminator field

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SerializationAnnotations.kt
@@ -12,6 +12,12 @@ sealed interface SerializationAnnotations {
     val supportsBackingPropertyForDiscriminator: Boolean
 
     /**
+     * Whether properties of a polymorphic super type may have backing fields that subtypes
+     * override and pass through the superclass constructor
+     */
+    val supportsInheritedBackingProperties: Boolean
+
+    /**
      * Whether the annotation supports OpenAPI's additional properties
      * https://spec.openapis.org/oas/v3.0.0.html#model-with-map-dictionary-properties
      */
@@ -29,7 +35,11 @@ sealed interface SerializationAnnotations {
     ): PropertySpec.Builder
     fun addClassAnnotation(typeSpecBuilder: TypeSpec.Builder): TypeSpec.Builder
     fun addBasePolymorphicTypeAnnotation(typeSpecBuilder: TypeSpec.Builder, propertyName: String): TypeSpec.Builder
-    fun addPolymorphicSubTypesAnnotation(typeSpecBuilder: TypeSpec.Builder, mappings: Map<String, TypeName>): TypeSpec.Builder
+    fun addPolymorphicSubTypesAnnotation(
+        typeSpecBuilder: TypeSpec.Builder,
+        mappings: Map<String, TypeName>,
+        enumDiscriminator: KotlinTypeInfo.Enum? = null,
+    ): TypeSpec.Builder
 
     /** Discriminator-less polymorphism for the sealed super-interface. No-op for libraries
      *  without a deduction equivalent (e.g. kotlinx). */

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ChildActionA.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ChildActionA.kt
@@ -4,6 +4,7 @@ import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+@SerialName("CHILD_A")
 @Serializable
 public data class ChildActionA(
   @SerialName("fieldA")

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ChildActionB.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ChildActionB.kt
@@ -4,6 +4,7 @@ import kotlin.Int
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+@SerialName("CHILD_B")
 @Serializable
 public data class ChildActionB(
   @SerialName("fieldB")

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DiscriminatedBase.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DiscriminatedBase.kt
@@ -1,20 +1,13 @@
 package examples.discriminatedOneOf.models
 
-import com.fasterxml.jackson.`annotation`.JsonSubTypes
-import com.fasterxml.jackson.`annotation`.JsonTypeInfo
 import kotlin.String
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
 
-@JsonTypeInfo(
-  use = JsonTypeInfo.Id.NAME,
-  include = JsonTypeInfo.As.EXISTING_PROPERTY,
-  property = "errorCode",
-  visible = true,
-)
-@JsonSubTypes(JsonSubTypes.Type(value = DiscriminatedChild::class, name = "ERR_ONE"))
+@JsonClassDiscriminator("errorCode")
+@ExperimentalSerializationApi
 @Serializable
-public sealed class DiscriminatedBase(
-  public open val message: String,
-) {
-  public abstract val errorCode: String
+public sealed class DiscriminatedBase() {
+  public abstract val message: String
 }

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DiscriminatedChild.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/DiscriminatedChild.kt
@@ -5,9 +5,10 @@ import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+@SerialName("ERR_ONE")
 @Serializable
 public data class DiscriminatedChild(
   @SerialName("message")
   @get:NotNull
   override val message: String,
-) : DiscriminatedBase(message)
+) : DiscriminatedBase()

--- a/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ParentAction.kt
+++ b/src/test/resources/examples/discriminatedOneOf/models/kotlinx/ParentAction.kt
@@ -1,18 +1,10 @@
 package examples.discriminatedOneOf.models
 
-import com.fasterxml.jackson.`annotation`.JsonSubTypes
-import com.fasterxml.jackson.`annotation`.JsonTypeInfo
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
 
-@JsonTypeInfo(
-  use = JsonTypeInfo.Id.NAME,
-  include = JsonTypeInfo.As.EXISTING_PROPERTY,
-  property = "actionType",
-  visible = true,
-)
-@JsonSubTypes(JsonSubTypes.Type(value = ChildActionA::class, name =
-    "CHILD_A"),JsonSubTypes.Type(value = ChildActionB::class, name = "CHILD_B"))
+@JsonClassDiscriminator("actionType")
+@ExperimentalSerializationApi
 @Serializable
-public sealed class ParentAction() {
-  public abstract val actionType: ParentActionActionType
-}
+public sealed class ParentAction()


### PR DESCRIPTION
With `KOTLINX_SERIALIZATION`, allOf child schemas of a discriminated parent generated code that did not compile: the sealed parent declared an abstract discriminator property that no child overrode. The parent also carried Jackson `@JsonTypeInfo`/`@JsonSubTypes` annotations regardless of the selected serialization library, and children were missing the class-level @SerialName mapping kotlinx needs to resolve subtypes.

kotlinx serialization emits the discriminator itself, and a property whose serial name matches the class discriminator fails at runtime, so the discriminator must not be a class property at all. The parent now gets `@JsonClassDiscriminator` (as the oneOf sealed interface path already does), children get `@SerialName` with their mapping key, and the abstract property and its overrides are omitted.

Inherited non-discriminator properties had a related defect: kotlinx includes superclass backing fields in the subclass serial state, so the generated open-property-with-constructor-passthrough pattern produced a duplicate serial name compile error. Super type properties are now generated as abstract for kotlinx and overridden in the subtypes.

Jackson output is unchanged.

Closes #627