### PR TITLE
Support remote api specification fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ java -jar fabrikt.jar \
     --http-client-opts resilience4j
 ```
 
+`--api-file` and `--api-fragment` also accept a resolvable `http://`/`https://` URL instead of a local path,
+in which case Fabrikt fetches the spec at generation time.
+Only fetch specs from URLs you trust — Fabrikt performs a plain, unauthenticated HTTP GET, so pointing it at an
+untrusted or attacker-influenced URL carries the same risk as fetching any other untrusted network resource.
+
 __Tip__: You can also run the latest version without a manual download via [JBang](https://www.jbang.dev/):
 
 ```
@@ -213,8 +218,8 @@ This section documents the available CLI parameters for controlling what gets ge
 
 | Parameter                      | Description |
 | ------------------------------ | ------------------------------ |
-|   `--api-file`                 | This must be a valid Open API v3 spec. All code generation will be based off this input. |
-|   `--api-fragment`             | A partial Open API v3 fragment, to be combined with the primary API for code generation purposes. |
+|   `--api-file`                 | This must be a valid Open API v3 spec. All code generation will be based off this input. Accepts either a local file path or a resolvable http(s) URL. |
+|   `--api-fragment`             | A partial Open API v3 fragment, to be combined with the primary API for code generation purposes. Accepts either a local file path or a resolvable http(s) URL. |
 | * `--base-package`             | The base package which all code will be generated under. |
 |   `--external-ref-resolution`  | Specify to which degree referenced schemas from external files are included in model generation. Default: TARGETED |
 |                                | CHOOSE ONE OF: |

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGen.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGen.kt
@@ -1,10 +1,9 @@
 package com.cjbooms.fabrikt.cli
 
-import com.beust.jcommander.ParameterException
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.MutableSettings
 import com.cjbooms.fabrikt.model.SourceApi
-import java.nio.file.Files
+import com.cjbooms.fabrikt.util.ApiFileLoader
 import java.nio.file.Path
 import java.util.logging.Logger
 
@@ -15,9 +14,6 @@ object CodeGen {
     @JvmStatic
     fun main(args: Array<String>) {
         val codeGenArgs = CodeGenArgs.parse(args)
-
-        if (Files.notExists(codeGenArgs.apiFile))
-            throw ParameterException("Could not find api file '${codeGenArgs.apiFile}', Specify its location with the -a option. Use --help for further information.")
 
         MutableSettings.updateSettings(
             genTypes = codeGenArgs.targets,
@@ -38,9 +34,9 @@ object CodeGen {
         )
         generate(
             basePackage = codeGenArgs.basePackage,
-            pathToApi = codeGenArgs.apiFile.toAbsolutePath(),
+            apiFile = codeGenArgs.apiFile,
             outputDir = codeGenArgs.outputDirectory,
-            apiFragments = codeGenArgs.apiFragments.map { it.toFile().readText() },
+            apiFragments = codeGenArgs.apiFragments,
             srcPath = codeGenArgs.srcPath,
             resourcesPath = codeGenArgs.resourcesPath,
         )
@@ -48,20 +44,19 @@ object CodeGen {
 
     private fun generate(
         basePackage: String,
-        pathToApi: Path,
+        apiFile: String,
         outputDir: Path,
         apiFragments: List<String> = emptyList(),
         srcPath: Path,
         resourcesPath: Path,
     ) {
-
-        val suppliedApi = pathToApi.toFile().readText()
-        val baseDir = pathToApi.parent
+        val suppliedApi = ApiFileLoader.load(apiFile, "--api-file")
+        val fragments = apiFragments.map { ApiFileLoader.load(it, "--api-fragment").content }
 
         logger.info("Generating code and dumping to $outputDir/")
 
         val packages = Packages(basePackage)
-        val sourceApi = SourceApi.create(suppliedApi, apiFragments, baseDir)
+        val sourceApi = SourceApi.create(suppliedApi.content, fragments, suppliedApi.baseUri)
         val generator = CodeGenerator(packages, sourceApi, srcPath, resourcesPath)
         generator.generate().forEach { it.writeFileTo(outputDir.toFile()) }
     }

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenArgs.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenArgs.kt
@@ -18,7 +18,7 @@ class CodeGenArgs {
 
     companion object {
         private const val DEFAULT_API_FILE_NAME = "api.yaml"
-        val DefaultApiPath: Path = Paths.get(".", DEFAULT_API_FILE_NAME)
+        const val DefaultApiFile: String = "./$DEFAULT_API_FILE_NAME"
 
         fun parse(args: Array<String>): CodeGenArgs {
             val codeGenArgs = CodeGenArgs()
@@ -59,17 +59,17 @@ class CodeGenArgs {
 
     @Parameter(
         names = ["--api-file"],
-        description = "This must be a valid Open API v3 spec. All code generation will be based off this input.",
-        converter = PathConverter::class
+        description = "This must be a valid Open API v3 spec. All code generation will be based off this input. " +
+            "Accepts either a local file path or a resolvable http(s) URL."
     )
-    var apiFile: Path = DefaultApiPath
+    var apiFile: String = DefaultApiFile
 
     @Parameter(
         names = ["--api-fragment"],
-        description = "A partial Open API v3 fragment, to be combined with the primary API for code generation purposes.",
-        converter = PathConverter::class
+        description = "A partial Open API v3 fragment, to be combined with the primary API for code generation purposes. " +
+            "Accepts either a local file path or a resolvable http(s) URL."
     )
-    var apiFragments: List<Path> = emptyList()
+    var apiFragments: List<String> = emptyList()
 
     @Parameter(
         names = ["--targets"],

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SourceApi.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SourceApi.kt
@@ -9,7 +9,7 @@ import com.cjbooms.fabrikt.validation.ValidationError
 import com.reprezen.jsonoverlay.Overlay
 import com.reprezen.kaizen.oasparser.model3.OpenApi3
 import com.reprezen.kaizen.oasparser.model3.Schema
-import java.nio.file.Path
+import java.net.URI
 import java.nio.file.Paths
 import java.util.logging.Logger
 
@@ -19,21 +19,21 @@ data class SchemaInfo(val name: String, val schema: Schema) {
 
 data class SourceApi(
     private val rawApiSpec: String,
-    val baseDir: Path = Paths.get("").toAbsolutePath(),
+    val baseUri: URI = Paths.get("").toAbsolutePath().toUri(),
 ) {
     companion object {
         fun create(
             baseApi: String,
             apiFragments: Collection<String>,
-            baseDir: Path = Paths.get("").toAbsolutePath(),
+            baseUri: URI = Paths.get("").toAbsolutePath().toUri(),
         ): SourceApi {
             val combinedApi =
                 apiFragments.fold(YamlUtils.expandYamlAliases(baseApi)) { acc: String, fragment -> YamlUtils.mergeYamlTrees(acc, fragment) }
-            return SourceApi(combinedApi, baseDir)
+            return SourceApi(combinedApi, baseUri)
         }
     }
 
-    val openApi3: OpenApi3 = YamlUtils.parseOpenApi(rawApiSpec, baseDir)
+    val openApi3: OpenApi3 = YamlUtils.parseOpenApi(rawApiSpec, baseUri)
     val allSchemas: List<SchemaInfo>
 
     init {

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/ApiFileLoader.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/ApiFileLoader.kt
@@ -1,0 +1,68 @@
+package com.cjbooms.fabrikt.util
+
+import com.beust.jcommander.ParameterException
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse.BodyHandlers
+import java.net.http.HttpTimeoutException
+import java.nio.file.Files
+import java.nio.file.InvalidPathException
+import java.nio.file.Paths
+import java.time.Duration
+
+data class LoadedApi(val content: String, val baseUri: URI)
+
+/**
+ * Loads an Open API spec or fragment from either a local file path or an `http(s)` URL.
+ */
+object ApiFileLoader {
+
+    private val CONNECT_TIMEOUT: Duration = Duration.ofSeconds(10)
+    private val REQUEST_TIMEOUT: Duration = Duration.ofSeconds(30)
+
+    private val httpClient: HttpClient by lazy {
+        HttpClient.newBuilder()
+            .connectTimeout(CONNECT_TIMEOUT)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build()
+    }
+
+    fun isRemote(value: String): Boolean =
+        runCatching { URI(value).scheme }.getOrNull()?.lowercase() in setOf("http", "https")
+
+    fun load(value: String, paramName: String): LoadedApi =
+        if (isRemote(value)) loadRemote(URI(value)) else loadLocal(value, paramName)
+
+    private fun loadLocal(value: String, paramName: String): LoadedApi {
+        val path = try {
+            Paths.get(value).toAbsolutePath()
+        } catch (e: InvalidPathException) {
+            throw ParameterException("'$value' is not a valid path for the $paramName option.", e)
+        }
+        if (Files.notExists(path)) {
+            throw ParameterException(
+                "Could not find api file '$value', Specify its location with the $paramName option. " +
+                    "Use --help for further information.",
+            )
+        }
+        val baseUri = (path.parent ?: path).toUri()
+        return LoadedApi(path.toFile().readText(), baseUri)
+    }
+
+    private fun loadRemote(uri: URI): LoadedApi {
+        val request = HttpRequest.newBuilder(uri).timeout(REQUEST_TIMEOUT).GET().build()
+        val response = try {
+            httpClient.send(request, BodyHandlers.ofString())
+        } catch (e: HttpTimeoutException) {
+            throw ParameterException("Timed out fetching api file from '$uri'", e)
+        } catch (e: IOException) {
+            throw ParameterException("Failed to fetch api file from '$uri'", e)
+        }
+        if (response.statusCode() !in 200..299) {
+            throw ParameterException("Failed to fetch api file from '$uri': received HTTP status ${response.statusCode()}")
+        }
+        return LoadedApi(response.body(), uri.resolve("."))
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/YamlUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/YamlUtils.kt
@@ -14,7 +14,7 @@ import com.reprezen.kaizen.oasparser.model3.OpenApi3
 import org.yaml.snakeyaml.DumperOptions
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
-import java.nio.file.Path
+import java.net.URI
 import java.nio.file.Paths
 
 object YamlUtils {
@@ -85,12 +85,12 @@ object YamlUtils {
             ),
         )!!
 
-    fun parseOpenApi(input: String, inputDir: Path = Paths.get("").toAbsolutePath()): OpenApi3 =
+    fun parseOpenApi(input: String, baseUri: URI = Paths.get("").toAbsolutePath().toUri()): OpenApi3 =
         try {
             val root: JsonNode = objectMapper.readTree(input)
             OpenApi31Downgrader.downgradeIncompatibleElements(root)
             cleanEmptyTypes(root)
-            OpenApi3Parser().parse(root, inputDir.toUri().toURL())
+            OpenApi3Parser().parse(root, baseUri.toURL())
         } catch (ex: NullPointerException) {
             throw IllegalArgumentException(
                 "The Kaizen openapi-parser library threw a NPE exception when parsing this API. " +

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
@@ -62,7 +62,7 @@ class KotlinSerializationModelGeneratorTest {
         }
         val basePackage = "examples.${testCaseName.replace("/", ".")}"
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
         val expectedModelsPath = "/examples/$testCaseName/models/kotlinx/"
         val expectedModels = getFileNamesInFolder(Path.of("src/test/resources$expectedModelsPath"))
 
@@ -97,7 +97,7 @@ class KotlinSerializationModelGeneratorTest {
     fun `schemas configured with additionalProperties results in UnsupportedOperationException`() {
         val basePackage = "examples.additionalProperties"
         val apiLocation = javaClass.getResource("/examples/additionalProperties/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
 
         val e = assertThrows<UnsupportedOperationException> {
             ModelGenerator(Packages(basePackage), sourceApi,).generate()
@@ -109,7 +109,7 @@ class KotlinSerializationModelGeneratorTest {
     fun `schemas without properties result in UnsupportedOperationException`() {
         val basePackage = "examples.untypedObject"
         val apiLocation = javaClass.getResource("/examples/untypedObject/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
 
         val e = assertThrows<UnsupportedOperationException> {
             val models = ModelGenerator(Packages(basePackage), sourceApi,).generate()
@@ -124,7 +124,7 @@ class KotlinSerializationModelGeneratorTest {
         MutableSettings.addOption(CodeGenTypeOverride.DATETIME_AS_INSTANT)
         val basePackage = "examples.kotlinxDateTimeOverrides"
         val apiLocation = javaClass.getResource("/examples/kotlinxDateTimeOverrides/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
         val expectedModels = readFolder(Path.of("src/test/resources/examples/kotlinxDateTimeOverrides/models/instant/"))
 
         val models = ModelGenerator(
@@ -156,7 +156,7 @@ class KotlinSerializationModelGeneratorTest {
         MutableSettings.addOption(CodeGenTypeOverride.DATETIME_AS_LOCALDATETIME)
         val basePackage = "examples.kotlinxDateTimeOverrides"
         val apiLocation = javaClass.getResource("/examples/kotlinxDateTimeOverrides/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
         val expectedModels = readFolder(Path.of("src/test/resources/examples/kotlinxDateTimeOverrides/models/localdatetime/"))
 
         val models = ModelGenerator(
@@ -188,7 +188,7 @@ class KotlinSerializationModelGeneratorTest {
         MutableSettings.addOption(CodeGenTypeOverride.ANY_AS_JSONELEMENT)
         val basePackage = "examples.anyAsJsonElement"
         val apiLocation = javaClass.getResource("/examples/anyAsJsonElement/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
         val expectedModels = readFolder(Path.of("src/test/resources/examples/anyAsJsonElement/models/kotlinx/"))
 
         val models = ModelGenerator(
@@ -225,7 +225,7 @@ class KotlinSerializationModelGeneratorTest {
         MutableSettings.addOption(CodeGenTypeOverride.BINARY_AS_STRING)
         val basePackage = "examples.primitiveTypes"
         val apiLocation = javaClass.getResource("/examples/primitiveTypes/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
         val expectedModels = readFolder(Path.of("src/test/resources/examples/primitiveTypes/models/kotlinxAsStringOverrides/"))
 
         val models = ModelGenerator(

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorClientGeneratorTest.kt
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import java.nio.file.Paths
 import java.util.stream.Stream
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -49,7 +48,7 @@ class KtorClientGeneratorTest {
     fun `correct Ktor client code is generated`(testCaseName: String) {
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
 
         val expectedClient = expectedClientPath(testCaseName, "KtorClient.kt")
 
@@ -69,7 +68,7 @@ class KtorClientGeneratorTest {
     fun `correct Ktor API models are generated`(testCaseName: String) {
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
 
         val expectedApiModels = "/examples/$testCaseName/client/ktor/KtorApiModels.kt"
 

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -126,7 +126,7 @@ class ModelGeneratorTest {
         }
         val basePackage = "examples.${testCaseName.replace("/", ".")}"
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
         val expectedModelsPath = "/examples/$testCaseName/models/"
         val expectedModels = getFileNamesInFolder(Path.of("src/test/resources$expectedModelsPath"))
 
@@ -170,7 +170,7 @@ class ModelGeneratorTest {
         MutableSettings.addOption(ModelCodeGenOptionType.FAULT_TOLERANT_ENUMS)
         val basePackage = "examples.openEnum"
         val apiLocation = javaClass.getResource("/examples/openEnum/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
 
         val models = ModelGenerator(
             Packages(basePackage),
@@ -202,7 +202,7 @@ class ModelGeneratorTest {
         )
         val basePackage = "examples.modelSuffix"
         val apiLocation = javaClass.getResource("/examples/modelSuffix/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
         val expectedModelsPath = "/examples/modelSuffix/models/"
 
         val models = ModelGenerator(
@@ -225,7 +225,7 @@ class ModelGeneratorTest {
         )
         val basePackage = "examples.fileComment"
         val apiLocation = javaClass.getResource("/examples/fileComment/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
         val expectedModelsPath = "/examples/fileComment/models/"
 
         val models = ModelGenerator(

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -63,7 +63,7 @@ class OkHttpClientGeneratorTest {
     fun `correct api simple client is generated from a full API definition`(testCaseName: String) {
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
 
         val expectedModel = "/examples/$testCaseName/models/ClientModels.kt"
         val expectedClient = expectedClientPath(testCaseName, "ApiClient.kt")
@@ -92,7 +92,7 @@ class OkHttpClientGeneratorTest {
     fun `correct api fault-tolerant service client is generated when the resilience4j option is set`(testCaseName: String) {
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
 
         val expectedLibUtil = "/examples/$testCaseName/client/HttpResilience4jUtil.kt"
         val expectedClientCode = expectedClientPath(testCaseName, "ApiService.kt")
@@ -116,7 +116,7 @@ class OkHttpClientGeneratorTest {
     fun `the enhanced client is not generated when no specific options are provided`(testCaseName: String) {
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
 
         val enhancedClientCode = OkHttpEnhancedClientGenerator(
             packages,
@@ -132,7 +132,7 @@ class OkHttpClientGeneratorTest {
     fun `correct http utility libraries are generated`(testCaseName: String) {
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
 
         val expectedHttpUtils = "/examples/$testCaseName/client/HttpUtil.kt"
 
@@ -159,7 +159,7 @@ class OkHttpClientGeneratorTest {
     fun `correct api client and models are generated with external reference solution mode AGGRESSIVE`() {
         val packages = Packages("examples.externalReferences.aggressive")
         val apiLocation = javaClass.getResource("/examples/externalReferences/aggressive/api.yaml")!!
-        val sourceApi = SourceApi(apiLocation.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
 
         val expectedModel = "/examples/externalReferences/aggressive/models/ClientModels.kt"
         val expectedClient = "/examples/externalReferences/aggressive/client/ApiClient.kt"

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ResourceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ResourceGeneratorTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import java.nio.file.Paths
 import java.util.stream.Stream
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -36,7 +35,7 @@ class ResourceGeneratorTest {
         print("Testcase: $testCaseName")
         val basePackage = "examples.$testCaseName"
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")
-        val sourceApi = SourceApi(apiLocation!!.readText(), baseDir = Paths.get(apiLocation.toURI()))
+        val sourceApi = SourceApi(apiLocation!!.readText(), baseUri = apiLocation.toURI())
         val expectedResource =
             javaClass.getResource("/examples/$testCaseName/resources/reflection-config.json")!!.readText()
         MutableSettings.updateSettings(

--- a/src/test/kotlin/com/cjbooms/fabrikt/util/ApiFileLoaderTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/util/ApiFileLoaderTest.kt
@@ -1,0 +1,112 @@
+package com.cjbooms.fabrikt.util
+
+import com.beust.jcommander.ParameterException
+import com.sun.net.httpserver.HttpServer
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ApiFileLoaderTest {
+
+    private lateinit var server: HttpServer
+
+    @BeforeEach
+    fun startServer() {
+        server = HttpServer.create(InetSocketAddress("localhost", 0), 0)
+        server.start()
+    }
+
+    @AfterEach
+    fun stopServer() {
+        server.stop(0)
+    }
+
+    private fun baseUrl() = "http://localhost:${server.address.port}"
+
+    private fun HttpServer.stub(path: String, status: Int, body: String? = null) {
+        createContext(path) { exchange ->
+            val bytes = body?.toByteArray(StandardCharsets.UTF_8)
+            exchange.sendResponseHeaders(status, bytes?.size?.toLong() ?: -1)
+            bytes?.let { exchange.responseBody.write(it) }
+            exchange.responseBody.close()
+        }
+    }
+
+    @Test
+    fun `isRemote is true only for http and https urls`() {
+        assertThat(ApiFileLoader.isRemote("http://example.com/api.yaml")).isTrue()
+        assertThat(ApiFileLoader.isRemote("https://example.com/api.yaml")).isTrue()
+        assertThat(ApiFileLoader.isRemote("HTTPS://example.com/api.yaml")).isTrue()
+        assertThat(ApiFileLoader.isRemote("./api.yaml")).isFalse()
+        assertThat(ApiFileLoader.isRemote("api.yaml")).isFalse()
+        assertThat(ApiFileLoader.isRemote("/tmp/api.yaml")).isFalse()
+        assertThat(ApiFileLoader.isRemote("ftp://example.com/api.yaml")).isFalse()
+    }
+
+    @Test
+    fun `loads spec content and base uri from a remote http url`() {
+        server.stub("/specs/api.yaml", 200, "openapi: 3.0.0")
+
+        val loaded = ApiFileLoader.load("${baseUrl()}/specs/api.yaml", "--api-file")
+
+        assertThat(loaded.content).isEqualTo("openapi: 3.0.0")
+        assertThat(loaded.baseUri.toString()).isEqualTo("${baseUrl()}/specs/")
+    }
+
+    @Test
+    fun `throws a clear parameter exception on a non-2xx response`() {
+        server.stub("/missing.yaml", 404)
+
+        assertThatThrownBy { ApiFileLoader.load("${baseUrl()}/missing.yaml", "--api-file") }
+            .isInstanceOf(ParameterException::class.java)
+            .hasMessageContaining("404")
+    }
+
+    @Test
+    fun `throws a clear parameter exception when the host cannot be reached`() {
+        assertThatThrownBy { ApiFileLoader.load("http://localhost:1/api.yaml", "--api-file") }
+            .isInstanceOf(ParameterException::class.java)
+    }
+
+    @Test
+    fun `loads spec content and base uri from a local file`(
+        @TempDir tempDir: Path,
+    ) {
+        val file = tempDir.resolve("api.yaml")
+        Files.writeString(file, "openapi: 3.0.0")
+
+        val loaded = ApiFileLoader.load(file.toString(), "--api-file")
+
+        assertThat(loaded.content).isEqualTo("openapi: 3.0.0")
+        assertThat(loaded.baseUri).isEqualTo(tempDir.toUri())
+    }
+
+    @Test
+    fun `throws a clear parameter exception when the local file does not exist`(
+        @TempDir tempDir: Path,
+    ) {
+        val missing = tempDir.resolve("missing.yaml")
+
+        assertThatThrownBy { ApiFileLoader.load(missing.toString(), "--api-file") }
+            .isInstanceOf(ParameterException::class.java)
+            .hasMessageContaining("Could not find api file")
+            .hasMessageContaining("--api-file")
+    }
+
+    @Test
+    fun `throws a clear parameter exception when the local path is syntactically invalid`() {
+        val invalidPath = "invalid" + Character.MIN_VALUE + "path.yaml"
+
+        assertThatThrownBy { ApiFileLoader.load(invalidPath, "--api-file") }
+            .isInstanceOf(ParameterException::class.java)
+            .hasMessageContaining("not a valid path")
+            .hasMessageContaining("--api-file")
+    }
+}


### PR DESCRIPTION

  --api-file and --api-fragment now accept a resolvable http:///https:// URL in addition to a local file path. When a URL is given, Fabrikt fetches the spec over HTTP at generation time instead of requiring it on disk.

Why

Teams that keep their OpenAPI spec in a central registry, artifact host, or another repo previously had to download it as a separate build step before running Fabrikt. This lets Fabrikt fetch it directly.

Compatibility & safety

- Backwards compatible: local-path invocations are untouched — same Paths.get/Files.notExists/readText calls, just reached through a branch. 
- Not a new trust boundary in the normal case — whoever controls --api-file already controls the whole build. Fetches are plain, unauthenticated GETs using the JVM's default ProxySelector (so standard -Dhttps.proxyHost/-Dhttp.nonProxyHosts settings are honored automatically); no TLS verification changes. README calls out that specs should only be fetched from trusted URLs.


closes #521 