### PR TITLE
fix: disable regular jar task so shadow jar is not overwritten

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,10 @@ dependencies {
 }
 
 tasks {
+    named<Jar>("jar") {
+        enabled = false
+    }
+
     val shadowJar by getting(ShadowJar::class) {
         manifest {
             attributes["Main-Class"] = "io.fabrikt.cli.CodeGen"


### PR DESCRIPTION
## Problem

`java -jar build/libs/fabrikt-*.jar` currently fails because the executable shadow jar is overwritten by the thin library jar produced by the standard `jar` task. Both tasks write to the same path (`archiveClassifier = ""`), so the final artifact has:

- No `Main-Class` manifest entry
- No bundled runtime dependencies (e.g. `kotlin-stdlib`)

This breaks the documented way of running Fabrikt from the release jar.

## Fix

Disable the standard `jar` task so that the `shadowJar` task is the sole producer of `build/libs/fabrikt-*.jar`.

## Impact on Maven Central publishing

No impact. The `maven-publish` block already declares its artifacts explicitly:

```kotlin
create<MavenPublication>("fabrikt") {
    artifact(tasks["shadowJar"])
    artifact(tasks["sourcesJar"])
    artifact(tasks["kotlinDocJar"])
}
```

It does not use `from(components["java"])`, so the published artifact has always been the shadow jar. Disabling the standard `jar` task only ensures that local `build/libs/fabrikt-*.jar` matches what is published, instead of being overwritten by the thin library jar.

## Verification

- `./gradlew clean shadowJar` now produces a ~16 MB jar with:
  ```
  Main-Class: io.fabrikt.cli.CodeGen
  ```
- `./gradlew clean build` passes.
- `java -jar build/libs/fabrikt-*.jar --help` prints usage.

The existing guava relocation rules are unchanged; this only affects which task wins the shared output file.