### PR TITLE
fix: match discriminator mapping keys on the full schema name

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -297,7 +297,7 @@ object KaizenParserExtensions {
     }
 
     fun Discriminator.mappingKeyForSchemaName(schemaName: String): String? =
-        mappings.filter { it.value.endsWith(schemaName) }.keys.firstOrNull()
+        mappings.filter { it.value.split("/").last() == schemaName }.keys.firstOrNull()
 
     fun Schema.isInlinedObjectUnderAllOf(): Boolean =
         Overlay.of(this).pathFromRoot

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KotlinSerializationModelGeneratorTest.kt
@@ -33,6 +33,7 @@ class KotlinSerializationModelGeneratorTest {
     @Suppress("unused")
     private fun testCases(): Stream<String> = Stream.of(
         "discriminatedOneOf",
+        "discriminatorMappingSuffix",
         "primitiveTypes",
         "normalizedNameConflation",
         "openEnum"

--- a/src/test/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensionsTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensionsTest.kt
@@ -1,6 +1,7 @@
 package com.cjbooms.fabrikt.util
 
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.basePath
+import com.cjbooms.fabrikt.util.KaizenParserExtensions.mappingKeyForSchemaName
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Test
@@ -35,6 +36,44 @@ class KaizenParserExtensionsTest {
     @Test
     fun `basePath returns empty when there are no servers`() {
         assertThat(apiWithServerUrl(null).basePath()).isEqualTo("")
+    }
+
+    @Test
+    fun `mappingKeyForSchemaName matches the full schema name, not a suffix of another schema name`() {
+        val spec =
+            """
+            |openapi: 3.0.0
+            |info:
+            |  title: test
+            |  version: 1.0.0
+            |paths: {}
+            |components:
+            |  schemas:
+            |    ParentAction:
+            |      type: object
+            |      discriminator:
+            |        propertyName: actionType
+            |        mapping:
+            |          XCHILD: '#/components/schemas/XChildActionA'
+            |          CHILD: '#/components/schemas/ChildActionA'
+            |      properties:
+            |        actionType:
+            |          type: string
+            |      required:
+            |        - actionType
+            |    ChildActionA:
+            |      allOf:
+            |        - ${'$'}ref: '#/components/schemas/ParentAction'
+            |    XChildActionA:
+            |      allOf:
+            |        - ${'$'}ref: '#/components/schemas/ParentAction'
+            """.trimMargin()
+        val discriminator = YamlUtils.parseOpenApi(spec).schemas["ParentAction"]!!.discriminator
+
+        assertThat(discriminator.mappingKeyForSchemaName("XChildActionA")).isEqualTo("XCHILD")
+        // '#/components/schemas/XChildActionA' ends with 'ChildActionA', so a plain endsWith
+        // match resolves ChildActionA to whichever mapping happens to come first.
+        assertThat(discriminator.mappingKeyForSchemaName("ChildActionA")).isEqualTo("CHILD")
     }
 
     @Test

--- a/src/test/resources/examples/discriminatorMappingSuffix/api.yaml
+++ b/src/test/resources/examples/discriminatorMappingSuffix/api.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: Discriminator mapping keys for schema names that are suffixes of each other
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    # XChildActionA ends with ChildActionA, so resolving a schema name to its mapping key
+    # must match the full ref segment, not just a suffix of the mapping value.
+    ParentAction:
+      type: object
+      discriminator:
+        propertyName: actionType
+        mapping:
+          XCHILD: '#/components/schemas/XChildActionA'
+          CHILD: '#/components/schemas/ChildActionA'
+      properties:
+        actionType:
+          type: string
+      required:
+        - actionType
+    ChildActionA:
+      allOf:
+        - $ref: '#/components/schemas/ParentAction'
+        - type: object
+          properties:
+            fieldA:
+              type: string
+    XChildActionA:
+      allOf:
+        - $ref: '#/components/schemas/ParentAction'
+        - type: object
+          properties:
+            fieldX:
+              type: string

--- a/src/test/resources/examples/discriminatorMappingSuffix/models/kotlinx/ChildActionA.kt
+++ b/src/test/resources/examples/discriminatorMappingSuffix/models/kotlinx/ChildActionA.kt
@@ -1,0 +1,12 @@
+package examples.discriminatorMappingSuffix.models
+
+import kotlin.String
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@SerialName("CHILD")
+@Serializable
+public data class ChildActionA(
+  @SerialName("fieldA")
+  public val fieldA: String? = null,
+) : ParentAction()

--- a/src/test/resources/examples/discriminatorMappingSuffix/models/kotlinx/ParentAction.kt
+++ b/src/test/resources/examples/discriminatorMappingSuffix/models/kotlinx/ParentAction.kt
@@ -1,0 +1,10 @@
+package examples.discriminatorMappingSuffix.models
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
+
+@JsonClassDiscriminator("actionType")
+@ExperimentalSerializationApi
+@Serializable
+public sealed class ParentAction()

--- a/src/test/resources/examples/discriminatorMappingSuffix/models/kotlinx/XChildActionA.kt
+++ b/src/test/resources/examples/discriminatorMappingSuffix/models/kotlinx/XChildActionA.kt
@@ -1,0 +1,12 @@
+package examples.discriminatorMappingSuffix.models
+
+import kotlin.String
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@SerialName("XCHILD")
+@Serializable
+public data class XChildActionA(
+  @SerialName("fieldX")
+  public val fieldX: String? = null,
+) : ParentAction()


### PR DESCRIPTION
`mappingKeyForSchemaName` resolved a schema name to its discriminator mapping with `endsWith`, so a schema whose name is a suffix of another (`ChildActionA` vs `XChildActionA`) could pick up the other schema's mapping key. With kotlinx serialization this gave both allOf children the same `@SerialName`, which is rejected at runtime for sealed subclasses. Match on the last path segment of the mapping ref instead.