### PR TITLE
fix: address nits from #651 review

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Usage: <main class> [options]
 |                                |   `SPRING_RESPONSE_ENTITY_WRAPPER` - This option adds the Spring-ResponseEntity generic around the response to be able to get response headers and status (only for OpenFeign clients). |
 |                                |   `SPRING_CLOUD_OPENFEIGN_STARTER_ANNOTATION` - This option adds the @FeignClient annotation to generated client interface |
 |                                |   `GROUP_BY_TAG` - This option groups clients based on the first tag rather than paths |
-|                                |   `OKHTTP_NON_NULL_RESPONSE_PAYLOADS` - This option makes ApiResponse.data non-null. Responses declared with a body must return one: a missing body, or one that deserializes to null, throws ApiException. An operation that declares both a body response and an empty success response (e.g. 200 and 204) throws on the empty success (only for OkHttp clients) |
+|                                |   `OKHTTP_NON_NULL_RESPONSE_PAYLOADS` - This option makes ApiResponse.data non-null. Responses declared with a body must return one: a missing body, or one that deserializes to null, throws ApiException. An operation that declares both a body response and an empty success response (e.g. 200 and 204) throws on the empty success. Binary responses return an empty ByteArray for an empty body (only for OkHttp clients) |
 |   `--http-client-target`       | Optionally select the target client that you want to be generated. Defaults to OK_HTTP |
 |                                | CHOOSE ONE OF: |
 |                                |   `OK_HTTP` - Generate OkHttp client. |

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -31,7 +31,7 @@ enum class ClientCodeGenOptionType(private val description: String) {
     SPRING_RESPONSE_ENTITY_WRAPPER("This option adds the Spring-ResponseEntity generic around the response to be able to get response headers and status (only for OpenFeign clients)."),
     SPRING_CLOUD_OPENFEIGN_STARTER_ANNOTATION("This option adds the @FeignClient annotation to generated client interface"),
     GROUP_BY_TAG("This option groups clients based on the first tag rather than paths"),
-    OKHTTP_NON_NULL_RESPONSE_PAYLOADS("This option makes ApiResponse.data non-null. Responses declared with a body must return one: a missing body, or one that deserializes to null, throws ApiException. An operation that declares both a body response and an empty success response (e.g. 200 and 204) throws on the empty success (only for OkHttp clients)")
+    OKHTTP_NON_NULL_RESPONSE_PAYLOADS("This option makes ApiResponse.data non-null. Responses declared with a body must return one: a missing body, or one that deserializes to null, throws ApiException. An operation that declares both a body response and an empty success response (e.g. 200 and 204) throws on the empty success. Binary responses return an empty ByteArray for an empty body (only for OkHttp clients)")
     ;
 
     override fun toString() = "`${super.toString()}` - $description"

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -121,7 +121,7 @@ data class SimpleClientOperationStatement(
     private val verb: String,
     private val operation: Operation,
     private val parameters: List<IncomingParameter>,
-    private val options: Set<ClientCodeGenOptionType> = emptySet()
+    private val options: Set<ClientCodeGenOptionType>
 ) {
     fun toStatement(): CodeBlock =
         CodeBlock.builder()


### PR DESCRIPTION
Small follow-up to #651 addressing the actionable review nits:

- Remove the default value for `SimpleClientOperationStatement.options` so future callsites can't silently forget to plumb options through.
- Clarify the `OKHTTP_NON_NULL_RESPONSE_PAYLOADS` option description to document that binary responses return an empty `ByteArray` for an empty body (in contrast to JSON responses, which throw).
- Regenerate the README CLI options table to match the updated description.

The unused-validation-dependencies nit was attempted but reverted: the generated models in `okhttp-non-null` reference `jakarta.validation.constraints.NotNull`, so the deps are required.

Build verified with `./gradlew build`.