### PR TITLE
fix: remove strange 8-space continuation indent in generated HttpUtil.kt

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpClientLibraryFiles.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpClientLibraryFiles.kt
@@ -132,9 +132,12 @@ object OkHttpClientLibraryFiles {
                     .addParameter("key", String::class)
                     .addParameter("value", TypeVariableName("T").copy(nullable = true))
                     .returns(httpUrlBuilder)
-                    .beginControlFlow("return this.apply")
-                    .addStatement("if·(value·!=·null)·this.addQueryParameter(key,·value.toString())")
-                    .endControlFlow()
+                    .addCode(
+                        """
+                        if (value != null) this.addQueryParameter(key, value.toString())
+                        return this
+                        """.trimIndent()
+                    )
                     .build()
             )
             .addFunction(
@@ -145,9 +148,12 @@ object OkHttpClientLibraryFiles {
                     .addParameter("key", String::class)
                     .addParameter("value", TypeVariableName("T").copy(nullable = true))
                     .returns(formBodyBuilder)
-                    .beginControlFlow("return this.apply")
-                    .addStatement("if·(value·!=·null)·this.add(key,·value.toString())")
-                    .endControlFlow()
+                    .addCode(
+                        """
+                        if (value != null) this.add(key, value.toString())
+                        return this
+                        """.trimIndent()
+                    )
                     .build()
             )
             .addFunction(
@@ -163,12 +169,15 @@ object OkHttpClientLibraryFiles {
                         ParameterSpec.builder("explode", Boolean::class).defaultValue("true").build()
                     )
                     .returns(httpUrlBuilder)
-                    .beginControlFlow("return this.apply")
-                    .beginControlFlow("if (values != null)")
-                    .addStatement("if·(explode)·values.forEach·{·addQueryParameter(key,·it.toString())·}")
-                    .addStatement("else·addQueryParameter(key,·values.joinToString(%S))", ",")
-                    .endControlFlow()
-                    .endControlFlow()
+                    .addCode(
+                        """
+                        if (values != null) {
+                            if (explode) values.forEach { addQueryParameter(key, it.toString()) }
+                            else addQueryParameter(key, values.joinToString(","))
+                        }
+                        return this
+                        """.trimIndent()
+                    )
                     .build()
             )
             .addFunction(
@@ -178,9 +187,12 @@ object OkHttpClientLibraryFiles {
                     .addParameter("key", String::class)
                     .addParameter("value", Any::class.asTypeName().copy(nullable = true))
                     .returns(headersBuilder)
-                    .beginControlFlow("return this.apply")
-                    .addStatement("if·(value·!=·null)·this.add(key,·value.toString())")
-                    .endControlFlow()
+                    .addCode(
+                        """
+                        if (value != null) this.add(key, value.toString())
+                        return this
+                        """.trimIndent()
+                    )
                     .build()
             )
             .addFunction(

--- a/src/test/resources/examples/byteArrayStream/client/HttpUtil.kt
+++ b/src/test/resources/examples/byteArrayStream/client/HttpUtil.kt
@@ -20,15 +20,15 @@ import okhttp3.Response
 import okhttp3.ResponseBody
 
 @Suppress("unused")
-public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder =
-        this.apply {
+public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder {
     if (value != null) this.addQueryParameter(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
-public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder =
-        this.apply {
+public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
@@ -36,16 +36,18 @@ public fun HttpUrl.Builder.queryParam(
     key: String,
     values: List<Any>?,
     explode: Boolean = true,
-): HttpUrl.Builder = this.apply {
+): HttpUrl.Builder {
     if (values != null) {
         if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
+    return this
 }
 
 @Suppress("unused")
-public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder = this.apply {
+public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/externalReferences/aggressive/client/HttpUtil.kt
+++ b/src/test/resources/examples/externalReferences/aggressive/client/HttpUtil.kt
@@ -20,15 +20,15 @@ import okhttp3.Response
 import okhttp3.ResponseBody
 
 @Suppress("unused")
-public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder =
-        this.apply {
+public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder {
     if (value != null) this.addQueryParameter(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
-public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder =
-        this.apply {
+public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
@@ -36,16 +36,18 @@ public fun HttpUrl.Builder.queryParam(
     key: String,
     values: List<Any>?,
     explode: Boolean = true,
-): HttpUrl.Builder = this.apply {
+): HttpUrl.Builder {
     if (values != null) {
         if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
+    return this
 }
 
 @Suppress("unused")
-public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder = this.apply {
+public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/multiMediaType/client/HttpUtil.kt
+++ b/src/test/resources/examples/multiMediaType/client/HttpUtil.kt
@@ -20,15 +20,15 @@ import okhttp3.Response
 import okhttp3.ResponseBody
 
 @Suppress("unused")
-public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder =
-        this.apply {
+public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder {
     if (value != null) this.addQueryParameter(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
-public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder =
-        this.apply {
+public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
@@ -36,16 +36,18 @@ public fun HttpUrl.Builder.queryParam(
     key: String,
     values: List<Any>?,
     explode: Boolean = true,
-): HttpUrl.Builder = this.apply {
+): HttpUrl.Builder {
     if (values != null) {
         if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
+    return this
 }
 
 @Suppress("unused")
-public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder = this.apply {
+public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/multipartUpload/client/HttpUtil.kt
+++ b/src/test/resources/examples/multipartUpload/client/HttpUtil.kt
@@ -20,15 +20,15 @@ import okhttp3.Response
 import okhttp3.ResponseBody
 
 @Suppress("unused")
-public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder =
-        this.apply {
+public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder {
     if (value != null) this.addQueryParameter(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
-public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder =
-        this.apply {
+public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
@@ -36,16 +36,18 @@ public fun HttpUrl.Builder.queryParam(
     key: String,
     values: List<Any>?,
     explode: Boolean = true,
-): HttpUrl.Builder = this.apply {
+): HttpUrl.Builder {
     if (values != null) {
         if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
+    return this
 }
 
 @Suppress("unused")
-public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder = this.apply {
+public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/okHttpClient/client/HttpUtil.kt
+++ b/src/test/resources/examples/okHttpClient/client/HttpUtil.kt
@@ -20,15 +20,15 @@ import okhttp3.Response
 import okhttp3.ResponseBody
 
 @Suppress("unused")
-public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder =
-        this.apply {
+public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder {
     if (value != null) this.addQueryParameter(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
-public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder =
-        this.apply {
+public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
@@ -36,16 +36,18 @@ public fun HttpUrl.Builder.queryParam(
     key: String,
     values: List<Any>?,
     explode: Boolean = true,
-): HttpUrl.Builder = this.apply {
+): HttpUrl.Builder {
     if (values != null) {
         if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
+    return this
 }
 
 @Suppress("unused")
-public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder = this.apply {
+public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/okHttpClientNonNullResponsePayloads/client/HttpUtil.kt
+++ b/src/test/resources/examples/okHttpClientNonNullResponsePayloads/client/HttpUtil.kt
@@ -21,15 +21,15 @@ import okhttp3.Response
 import okhttp3.ResponseBody
 
 @Suppress("unused")
-public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder =
-        this.apply {
+public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder {
     if (value != null) this.addQueryParameter(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
-public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder =
-        this.apply {
+public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
@@ -37,16 +37,18 @@ public fun HttpUrl.Builder.queryParam(
     key: String,
     values: List<Any>?,
     explode: Boolean = true,
-): HttpUrl.Builder = this.apply {
+): HttpUrl.Builder {
     if (values != null) {
         if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
+    return this
 }
 
 @Suppress("unused")
-public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder = this.apply {
+public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/HttpUtil.kt
+++ b/src/test/resources/examples/okHttpClientPostWithoutRequestBody/client/HttpUtil.kt
@@ -20,15 +20,15 @@ import okhttp3.Response
 import okhttp3.ResponseBody
 
 @Suppress("unused")
-public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder =
-        this.apply {
+public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder {
     if (value != null) this.addQueryParameter(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
-public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder =
-        this.apply {
+public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
@@ -36,16 +36,18 @@ public fun HttpUrl.Builder.queryParam(
     key: String,
     values: List<Any>?,
     explode: Boolean = true,
-): HttpUrl.Builder = this.apply {
+): HttpUrl.Builder {
     if (values != null) {
         if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
+    return this
 }
 
 @Suppress("unused")
-public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder = this.apply {
+public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/parameterNameClash/client/HttpUtil.kt
+++ b/src/test/resources/examples/parameterNameClash/client/HttpUtil.kt
@@ -20,15 +20,15 @@ import okhttp3.Response
 import okhttp3.ResponseBody
 
 @Suppress("unused")
-public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder =
-        this.apply {
+public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder {
     if (value != null) this.addQueryParameter(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
-public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder =
-        this.apply {
+public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
@@ -36,16 +36,18 @@ public fun HttpUrl.Builder.queryParam(
     key: String,
     values: List<Any>?,
     explode: Boolean = true,
-): HttpUrl.Builder = this.apply {
+): HttpUrl.Builder {
     if (values != null) {
         if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
+    return this
 }
 
 @Suppress("unused")
-public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder = this.apply {
+public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Throws(ApiException::class)

--- a/src/test/resources/examples/pathLevelParameters/client/HttpUtil.kt
+++ b/src/test/resources/examples/pathLevelParameters/client/HttpUtil.kt
@@ -20,15 +20,15 @@ import okhttp3.Response
 import okhttp3.ResponseBody
 
 @Suppress("unused")
-public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder =
-        this.apply {
+public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder {
     if (value != null) this.addQueryParameter(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
-public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder =
-        this.apply {
+public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Suppress("unused")
@@ -36,16 +36,18 @@ public fun HttpUrl.Builder.queryParam(
     key: String,
     values: List<Any>?,
     explode: Boolean = true,
-): HttpUrl.Builder = this.apply {
+): HttpUrl.Builder {
     if (values != null) {
         if (explode) values.forEach { addQueryParameter(key, it.toString()) }
         else addQueryParameter(key, values.joinToString(","))
     }
+    return this
 }
 
 @Suppress("unused")
-public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder = this.apply {
+public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder {
     if (value != null) this.add(key, value.toString())
+    return this
 }
 
 @Throws(ApiException::class)


### PR DESCRIPTION
Follow-up to #651 / #652.

The KotlinPoet expression bodies for `queryParam`, `formParam`, and `header` were wrapping after `=`, producing an 8-space continuation indent and an under-indented body block:

```kotlin
public fun ... queryParam(...): HttpUrl.Builder =
        this.apply {
    if (value != null) ...
}
```

This replaces the `this.apply { ... }` expression bodies with plain block bodies, eliminating the double indent:

```kotlin
public fun ... queryParam(...): HttpUrl.Builder {
    if (value != null) ...
    return this
}
```

Regenerated all affected `HttpUtil.kt` golden files.

Build verified with `./gradlew build`.