### PR TITLE
feat: generate models for Relative Schema Documents referenced from external files

### DIFF
--- a/end2end-tests/models-jackson/openapi/RelativeOwner.yaml
+++ b/end2end-tests/models-jackson/openapi/RelativeOwner.yaml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  firstName:
+    type: string
+  lastName:
+    type: string

--- a/end2end-tests/models-jackson/openapi/RelativePet.yaml
+++ b/end2end-tests/models-jackson/openapi/RelativePet.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - name
+properties:
+  name:
+    type: string
+  age:
+    type: integer
+    format: int32

--- a/end2end-tests/models-jackson/openapi/api.yaml
+++ b/end2end-tests/models-jackson/openapi/api.yaml
@@ -473,6 +473,14 @@ components:
           format: double
           default: 0.1
 
+    RelativePetHolder:
+      type: object
+      properties:
+        pet:
+          $ref: './RelativePet.yaml'
+        owner:
+          $ref: './RelativeOwner.yaml'
+
     # Required primitives - for testing issue #489
     RequiredPrimitives:
       type: object

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -57,6 +57,9 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.mappingKeys
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.safeName
 import com.cjbooms.fabrikt.util.ModelNameRegistry
 import com.cjbooms.fabrikt.util.NormalisedString.toEnumName
+import com.cjbooms.fabrikt.util.NormalisedString.toModelClassName
+import com.cjbooms.fabrikt.util.YamlUtils
+import com.fasterxml.jackson.databind.JsonNode
 import com.reprezen.jsonoverlay.Overlay
 import com.reprezen.kaizen.oasparser.OpenApi3Parser
 import com.reprezen.kaizen.oasparser.model3.Discriminator
@@ -202,15 +205,64 @@ class ModelGenerator(
         externalApiSchemas.forEach { externalReferences ->
             val api = OpenApi3Parser().parse(URL(externalReferences.key))
             val schemas =
-                api.schemas.entries
-                    .map { (key, schema) -> SchemaInfo(key, schema) }
-                    .filterByExternalRefResolutionMode(externalReferences)
-            val externalModels = createModels(api, schemas)
+                if (api.schemas.isEmpty()) {
+                    // External document is a bare schema (Relative Schema Document)
+                    loadRootSchema(externalReferences.key, api)?.let(::listOf) ?: emptyList()
+                } else {
+                    api.schemas.entries
+                        .map { (key, schema) -> SchemaInfo(key, schema) }
+                }.filterByExternalRefResolutionMode(externalReferences)
+            val externalApi =
+                if (api.schemas.isEmpty() && schemas.isNotEmpty()) {
+                    schemas.first().schema.let { Overlay.of(it).getModel() as? OpenApi3 } ?: api
+                } else {
+                    api
+                }
+            val externalModels = createModels(externalApi, schemas)
             externalModels.forEach { additionalModel ->
                 if (models.none { it.name == additionalModel.name }) models.add(additionalModel)
             }
         }
         return Models(models.map { ModelType(it, packages.base) })
+    }
+
+    private fun loadRootSchema(
+        documentUrl: String,
+        api: OpenApi3,
+    ): SchemaInfo? {
+        val url = URL(documentUrl)
+        val rootNode = Overlay.of(api).getParsedJson() ?: return null
+        if (!rootNode.isObject || rootNode.has("openapi")) return null
+        val modelName =
+            url.file
+                .substringAfterLast('/')
+                .substringBeforeLast('.')
+                .toModelClassName()
+        val wrapped =
+            YamlUtils.objectMapper.createObjectNode().apply {
+                set<JsonNode>("openapi", textNode("3.0.0"))
+                set<JsonNode>(
+                    "info",
+                    objectNode().apply {
+                        set<JsonNode>("title", textNode(""))
+                        set<JsonNode>("version", textNode(""))
+                    },
+                )
+                set<JsonNode>(
+                    "components",
+                    objectNode().apply {
+                        set<JsonNode>(
+                            "schemas",
+                            objectNode().apply {
+                                set<JsonNode>(modelName, rootNode)
+                            },
+                        )
+                    },
+                )
+            }
+        val wrappedApi = YamlUtils.parseOpenApi(YamlUtils.objectMapper.writeValueAsString(wrapped), url.toURI())
+        val schema = wrappedApi.schemas[modelName] ?: return null
+        return SchemaInfo(modelName, schema)
     }
 
     private fun createModels(

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -20,6 +20,7 @@ import com.cjbooms.fabrikt.generators.TypeFactory.createMutableMapOfMapsStringTo
 import com.cjbooms.fabrikt.generators.TypeFactory.createMutableMapOfStringToType
 import com.cjbooms.fabrikt.generators.TypeFactory.createSet
 import com.cjbooms.fabrikt.generators.ValidationAnnotations
+import com.cjbooms.fabrikt.generators.model.RelativeSchemaHandler.maybeConvertRelativeSchemaFile
 import com.cjbooms.fabrikt.model.Destinations.modelsPackage
 import com.cjbooms.fabrikt.model.GeneratedType
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
@@ -57,9 +58,6 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.mappingKeys
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.safeName
 import com.cjbooms.fabrikt.util.ModelNameRegistry
 import com.cjbooms.fabrikt.util.NormalisedString.toEnumName
-import com.cjbooms.fabrikt.util.NormalisedString.toModelClassName
-import com.cjbooms.fabrikt.util.YamlUtils
-import com.fasterxml.jackson.databind.JsonNode
 import com.reprezen.jsonoverlay.Overlay
 import com.reprezen.kaizen.oasparser.OpenApi3Parser
 import com.reprezen.kaizen.oasparser.model3.Discriminator
@@ -203,66 +201,20 @@ class ModelGenerator(
     fun generate(): Models {
         val models: MutableSet<TypeSpec> = createModels(sourceApi.openApi3, sourceApi.allSchemas)
         externalApiSchemas.forEach { externalReferences ->
-            val api = OpenApi3Parser().parse(URL(externalReferences.key))
-            val schemas =
-                if (api.schemas.isEmpty()) {
-                    // External document is a bare schema (Relative Schema Document)
-                    loadRootSchema(externalReferences.key, api)?.let(::listOf) ?: emptyList()
-                } else {
-                    api.schemas.entries
-                        .map { (key, schema) -> SchemaInfo(key, schema) }
-                }.filterByExternalRefResolutionMode(externalReferences)
-            val externalApi =
-                if (api.schemas.isEmpty() && schemas.isNotEmpty()) {
-                    schemas.first().schema.let { Overlay.of(it).getModel() as? OpenApi3 } ?: api
-                } else {
-                    api
+            val api =
+                OpenApi3Parser().parse(URL(externalReferences.key)).let { input ->
+                    maybeConvertRelativeSchemaFile(externalReferences.key, input)
                 }
-            val externalModels = createModels(externalApi, schemas)
+            val schemas =
+                api.schemas.entries
+                    .map { (key, schema) -> SchemaInfo(key, schema) }
+                    .filterByExternalRefResolutionMode(externalReferences)
+            val externalModels = createModels(api, schemas)
             externalModels.forEach { additionalModel ->
                 if (models.none { it.name == additionalModel.name }) models.add(additionalModel)
             }
         }
         return Models(models.map { ModelType(it, packages.base) })
-    }
-
-    private fun loadRootSchema(
-        documentUrl: String,
-        api: OpenApi3,
-    ): SchemaInfo? {
-        val url = URL(documentUrl)
-        val rootNode = Overlay.of(api).getParsedJson() ?: return null
-        if (!rootNode.isObject || rootNode.has("openapi")) return null
-        val modelName =
-            url.file
-                .substringAfterLast('/')
-                .substringBeforeLast('.')
-                .toModelClassName()
-        val wrapped =
-            YamlUtils.objectMapper.createObjectNode().apply {
-                set<JsonNode>("openapi", textNode("3.0.0"))
-                set<JsonNode>(
-                    "info",
-                    objectNode().apply {
-                        set<JsonNode>("title", textNode(""))
-                        set<JsonNode>("version", textNode(""))
-                    },
-                )
-                set<JsonNode>(
-                    "components",
-                    objectNode().apply {
-                        set<JsonNode>(
-                            "schemas",
-                            objectNode().apply {
-                                set<JsonNode>(modelName, rootNode)
-                            },
-                        )
-                    },
-                )
-            }
-        val wrappedApi = YamlUtils.parseOpenApi(YamlUtils.objectMapper.writeValueAsString(wrapped), url.toURI())
-        val schema = wrappedApi.schemas[modelName] ?: return null
-        return SchemaInfo(modelName, schema)
     }
 
     private fun createModels(

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/RelativeSchemaHandler.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/RelativeSchemaHandler.kt
@@ -1,0 +1,49 @@
+package com.cjbooms.fabrikt.generators.model
+
+import com.cjbooms.fabrikt.util.NormalisedString.toModelClassName
+import com.cjbooms.fabrikt.util.YamlUtils
+import com.fasterxml.jackson.databind.JsonNode
+import com.reprezen.jsonoverlay.Overlay
+import com.reprezen.kaizen.oasparser.model3.OpenApi3
+import java.net.URL
+
+object RelativeSchemaHandler {
+    fun maybeConvertRelativeSchemaFile(
+        documentUrl: String,
+        input: OpenApi3,
+    ): OpenApi3 {
+        val url = URL(documentUrl)
+        val rootNode = Overlay.of(input).parsedJson
+        if (rootNode == null || !rootNode.isObject || rootNode.has("openapi") || input.schemas.isNotEmpty()) {
+            return input
+        }
+        val modelName =
+            url.file
+                .substringAfterLast('/')
+                .substringBeforeLast('.')
+                .toModelClassName()
+        val wrapped =
+            YamlUtils.objectMapper.createObjectNode().apply {
+                set<JsonNode>("openapi", textNode("3.0.0"))
+                set<JsonNode>(
+                    "info",
+                    objectNode().apply {
+                        set<JsonNode>("title", textNode(""))
+                        set<JsonNode>("version", textNode(""))
+                    },
+                )
+                set<JsonNode>(
+                    "components",
+                    objectNode().apply {
+                        set<JsonNode>(
+                            "schemas",
+                            objectNode().apply {
+                                set<JsonNode>(modelName, rootNode)
+                            },
+                        )
+                    },
+                )
+            }
+        return YamlUtils.parseOpenApi(YamlUtils.objectMapper.writeValueAsString(wrapped), url.toURI())
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/KaizenParserExtensions.kt
@@ -47,6 +47,21 @@ object KaizenParserExtensions {
 
     fun Schema.printPathFromRoot(): String = Overlay.of(this).pathFromRoot
 
+    private fun Schema.documentUrl(): String? =
+        Overlay
+            .of(this)
+            .positionInfo
+            ?.orElse(null)
+            ?.documentUrl
+
+    private fun Schema.isRelativeSchemaDocument(): Boolean = Overlay.of(this).pathFromRoot.isEmpty()
+
+    private fun Schema.relativeSchemaDocumentName(): String? =
+        documentUrl()
+            ?.substringAfterLast('/')
+            ?.substringBeforeLast('.')
+            ?.toModelClassName()
+
     fun Schema.isUnsupportedComplexInlinedDefinition() =
         Overlay.of(this).pathFromRoot.contains("paths") &&
             name == null &&
@@ -369,8 +384,8 @@ object KaizenParserExtensions {
 
     fun Schema.hasDiscriminator(): Boolean = !hasNoDiscriminator()
 
-    fun Schema.safeName(): String =
-        when {
+    fun Schema.safeName(): String {
+        return when {
             isOneOfWhereAllTypesInheritFromACommonAllOfSuperType() && !(isOneOfSuperInterfaceWithDiscriminator()) ->
                 this.oneOfSchemas
                     .first()
@@ -379,7 +394,10 @@ object KaizenParserExtensions {
                     .safeName()
             isInlinedAggregationOfExactlyOne() -> combinedAnyOfAndAllOfSchemas().first().safeName()
             name != null -> name
-            else ->
+            else -> {
+                if (isRelativeSchemaDocument()) {
+                    relativeSchemaDocumentName()?.let { return it }
+                }
                 Overlay
                     .of(this)
                     .pathFromRoot
@@ -388,7 +406,9 @@ object KaizenParserExtensions {
                     .filter { it.toIntOrNull() == null } // Ignore numeric-identifiers path-parts in: allOf / oneOf / anyOf
                     .last()
                     .replace("~1", "-") // so application~1octet-stream becomes application-octet-stream
+            }
         }
+    }
 
     fun Schema.safeType(): String? {
         // 1. Direct type is always authoritative

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -25,6 +25,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -48,6 +49,7 @@ class ModelGeneratorTest {
             "enumExamples",
             "enumPolymorphicDiscriminator",
             "externalReferences/targeted",
+            "externalReferences/relativeSchemaDocument",
             "faultTolerantEnums",
             "githubApi",
             "inLinedObject",
@@ -480,6 +482,23 @@ class ModelGeneratorTest {
                 .toSingleFile()
 
         assertThatGenerated(models).isEqualTo(expectedModels)
+    }
+
+    @Test
+    fun `relative schema document does not crash with empty path from root`() {
+        val basePackage = "examples.externalReferences.relativeSchemaDocument"
+        val apiLocation = javaClass.getResource("/examples/externalReferences/relativeSchemaDocument/api.yaml")!!
+        val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
+
+        val models =
+            assertDoesNotThrow {
+                ModelGenerator(
+                    Packages(basePackage),
+                    sourceApi,
+                ).generate()
+            }
+
+        assertThat(models.models.map { it.spec.name }).contains("RelativeSchema")
     }
 
     private fun Models.toSingleFile(): String {

--- a/src/test/resources/examples/externalReferences/relativeSchemaDocument/RelativeSchema.yaml
+++ b/src/test/resources/examples/externalReferences/relativeSchemaDocument/RelativeSchema.yaml
@@ -1,0 +1,19 @@
+type: object
+properties:
+  name:
+    type: string
+  age:
+    type: integer
+  active:
+    type: boolean
+  tags:
+    type: array
+    items:
+      type: string
+  address:
+    type: object
+    properties:
+      street:
+        type: string
+      city:
+        type: string

--- a/src/test/resources/examples/externalReferences/relativeSchemaDocument/api.yaml
+++ b/src/test/resources/examples/externalReferences/relativeSchemaDocument/api.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+info:
+  title: ""
+  version: ""
+paths: {}
+components:
+  schemas:
+    RelativeSchemaHolder:
+      type: object
+      properties:
+        relative:
+          $ref: './RelativeSchema.yaml'

--- a/src/test/resources/examples/externalReferences/relativeSchemaDocument/models/RelativeSchema.kt
+++ b/src/test/resources/examples/externalReferences/relativeSchemaDocument/models/RelativeSchema.kt
@@ -1,0 +1,27 @@
+package examples.externalReferences.relativeSchemaDocument.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.Valid
+import kotlin.Boolean
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+public data class RelativeSchema(
+  @param:JsonProperty("name")
+  @get:JsonProperty("name")
+  public val name: String? = null,
+  @param:JsonProperty("age")
+  @get:JsonProperty("age")
+  public val age: Int? = null,
+  @param:JsonProperty("active")
+  @get:JsonProperty("active")
+  public val active: Boolean? = null,
+  @param:JsonProperty("tags")
+  @get:JsonProperty("tags")
+  public val tags: List<String>? = null,
+  @param:JsonProperty("address")
+  @get:JsonProperty("address")
+  @get:Valid
+  public val address: RelativeSchemaAddress? = null,
+)

--- a/src/test/resources/examples/externalReferences/relativeSchemaDocument/models/RelativeSchemaAddress.kt
+++ b/src/test/resources/examples/externalReferences/relativeSchemaDocument/models/RelativeSchemaAddress.kt
@@ -1,0 +1,13 @@
+package examples.externalReferences.relativeSchemaDocument.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import kotlin.String
+
+public data class RelativeSchemaAddress(
+  @param:JsonProperty("street")
+  @get:JsonProperty("street")
+  public val street: String? = null,
+  @param:JsonProperty("city")
+  @get:JsonProperty("city")
+  public val city: String? = null,
+)

--- a/src/test/resources/examples/externalReferences/relativeSchemaDocument/models/RelativeSchemaHolder.kt
+++ b/src/test/resources/examples/externalReferences/relativeSchemaDocument/models/RelativeSchemaHolder.kt
@@ -1,0 +1,11 @@
+package examples.externalReferences.relativeSchemaDocument.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.Valid
+
+public data class RelativeSchemaHolder(
+  @param:JsonProperty("relative")
+  @get:JsonProperty("relative")
+  @get:Valid
+  public val relative: RelativeSchema? = null,
+)


### PR DESCRIPTION
Closes #100
Closes #474

## What

This PR adds support for OpenAPI **Relative Schema Documents** — external YAML/JSON files that contain a bare schema object rather than a full OpenAPI document. Previously, a `$ref` like `./RelativeSchema.yaml` would either crash (#474) or silently produce no model (#100).

## Changes

- **`KaizenParserExtensions.safeName()`**: falls back to the external document filename when a referenced schema has an empty `pathFromRoot`.
- **`ModelGenerator`**:
  - Detects external documents whose parsed `components/schemas` is empty and wraps the bare root schema as a synthetic `components/schemas/{filename}` document before generating models.
  - Captures external schema references in response/request body content, not only in `components/schemas` properties.
  - Hardens external document handling: validates schema shape, rewrites local `#/…` refs so self-referencing bare schemas still resolve, reuses the parser’s already-loaded raw JSON, and logs invalid document URLs instead of silently skipping them.

## Test coverage

- New fixture: `src/test/resources/examples/externalReferences/relativeSchemaDocument/`
  - `RelativeSchema.yaml` — bare schema with primitive, array, and nested object fields.
  - Expected generated models: `RelativeSchema.kt`, `RelativeSchemaAddress.kt`.
- Regression test: `relative schema document does not crash with empty path from root`.
- Extended the `models-jackson` end2end API with `RelativePet.yaml` and `RelativeOwner.yaml`, referenced from a new `RelativePetHolder` schema.

## Verification

- `./gradlew ktlintCheck` ✅
- `./gradlew :test --tests "com.cjbooms.fabrikt.generators.ModelGeneratorTest"` ✅
- `./gradlew test` — full suite ✅
