### PR TITLE
feat: add first-class Jackson 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ Usage: <main class> [options]
 |   `--resources-path`           | Allows the path for generated resources to be overridden. Defaults to `src/main/resources` |
 |   `--serialization-library`    | Specify which serialization library to use for annotations in generated model classes. Default: JACKSON |
 |                                | CHOOSE ONE OF: |
-|                                |   `JACKSON` - Use Jackson for serialization and deserialization |
+|                                |   `JACKSON` - Use Jackson 2 for serialization and deserialization |
+|                                |   `JACKSON_3` - Use Jackson 3 for serialization and deserialization |
 |                                |   `KOTLINX_SERIALIZATION` - Use kotlinx.serialization for serialization and deserialization |
 |   `--src-path`                 | Allows the path for generated source files to be overridden. Defaults to `src/main/kotlin` |
 |   `--targets`                  | Targets are the parts of the application that you want to be generated. |

--- a/end2end-tests/okhttp-jackson3/build.gradle.kts
+++ b/end2end-tests/okhttp-jackson3/build.gradle.kts
@@ -1,0 +1,88 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+val generationDir = "$buildDir/generated"
+val nullableGenerationDir = "$buildDir/generated-nullable"
+val apiFile = "${rootProject.projectDir}/src/test/resources/examples/okHttpClient/api.yaml"
+val nullableApiFile = "${rootProject.projectDir}/src/test/resources/examples/customExtensions/api.yaml"
+
+sourceSets {
+    main {
+        java.srcDirs(
+            "$generationDir/src/main/kotlin",
+            "$nullableGenerationDir/src/main/kotlin",
+        )
+    }
+    test { java.srcDirs("$generationDir/src/test/kotlin") }
+}
+
+plugins {
+    kotlin("jvm")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+dependencies {
+    implementation(platform(libs.jackson3.bom))
+    implementation(libs.jackson3.module.kotlin)
+    implementation(libs.jackson3.databind)
+    implementation(libs.jackson.databind.nullable)
+    implementation(libs.okhttp)
+    implementation(libs.jakarta.validation.api)
+
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.bundles.junit)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.bundles.wiremock)
+}
+
+tasks {
+    val generateCode by creating(JavaExec::class) {
+        inputs.files(apiFile)
+        outputs.dir(generationDir)
+        outputs.cacheIf { true }
+        classpath = rootProject.files("./build/libs/fabrikt-${rootProject.version}.jar")
+        mainClass.set("io.fabrikt.cli.CodeGen")
+        args = listOf(
+            "--output-directory", generationDir,
+            "--base-package", "com.example",
+            "--api-file", apiFile,
+            "--targets", "http_models",
+            "--targets", "client",
+            "--serialization-library", "jackson_3",
+            "--http-model-opts", "DISABLE_SEALED_INTERFACES_FOR_ONE_OF",
+        )
+        dependsOn(":jar")
+        dependsOn(":shadowJar")
+    }
+
+    val generateNullableCode by creating(JavaExec::class) {
+        inputs.files(nullableApiFile)
+        outputs.dir(nullableGenerationDir)
+        outputs.cacheIf { true }
+        classpath = rootProject.files("./build/libs/fabrikt-${rootProject.version}.jar")
+        mainClass.set("io.fabrikt.cli.CodeGen")
+        args = listOf(
+            "--output-directory", nullableGenerationDir,
+            "--base-package", "com.example.nullable",
+            "--api-file", nullableApiFile,
+            "--targets", "http_models",
+            "--serialization-library", "jackson_3",
+        )
+        dependsOn(":jar")
+        dependsOn(":shadowJar")
+    }
+
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        compilerOptions.jvmTarget.set(JvmTarget.JVM_17)
+        dependsOn(generateCode)
+        dependsOn(generateNullableCode)
+    }
+
+    withType<Test> {
+        useJUnitPlatform()
+        jvmArgs = listOf("--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED")
+    }
+}

--- a/end2end-tests/okhttp-jackson3/src/test/kotlin/com/cjbooms/fabrikt/clients/Jackson3OkHttpClientTest.kt
+++ b/end2end-tests/okhttp-jackson3/src/test/kotlin/com/cjbooms/fabrikt/clients/Jackson3OkHttpClientTest.kt
@@ -1,0 +1,71 @@
+package com.cjbooms.fabrikt.clients
+
+import com.example.client.ExamplePath1Client
+import com.example.models.FirstModel
+import com.example.models.QueryResult
+import com.example.nullable.models.InnerNotMergePatch
+import com.example.nullable.models.TopLevelLevelMergePatchRef
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import com.marcinziolo.kotlin.wiremock.get
+import com.marcinziolo.kotlin.wiremock.like
+import com.marcinziolo.kotlin.wiremock.returns
+import java.net.ServerSocket
+import okhttp3.OkHttpClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.openapitools.jackson.nullable.JsonNullable
+import org.openapitools.jackson.nullable.JsonNullableJackson3Module
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+
+class Jackson3OkHttpClientTest {
+    private val port: Int = ServerSocket(0).use { socket -> socket.localPort }
+    private val wiremock = WireMockServer(options().port(port).notifier(ConsoleNotifier(true)))
+    private val mapper = JsonMapper.builder()
+        .addModule(kotlinModule())
+        .addModule(JsonNullableJackson3Module())
+        .build()
+    private val client = ExamplePath1Client(mapper, "http://localhost:$port", OkHttpClient())
+
+    @BeforeEach
+    fun setUp() {
+        wiremock.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        wiremock.resetAll()
+        wiremock.stop()
+    }
+
+    @Test
+    fun `Jackson 3 serializes and deserializes an OkHttp response`() {
+        val expected = QueryResult(listOf(FirstModel(id = "jackson-3")))
+        wiremock.get {
+            url like "/example-path-1"
+        } returns {
+            statusCode = 200
+            body = mapper.writeValueAsString(expected)
+        }
+
+        val response = client.getExamplePath1()
+
+        assertThat(response.data).isEqualTo(expected)
+    }
+
+    @Test
+    fun `Jackson 3 supports generated JsonNullable models`() {
+        val expected = TopLevelLevelMergePatchRef(
+            inner = JsonNullable.of(InnerNotMergePatch(p = "jackson-3")),
+        )
+
+        val json = mapper.writeValueAsString(expected)
+        val result = mapper.readValue(json, TopLevelLevelMergePatchRef::class.java)
+
+        assertThat(result).isEqualTo(expected)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,8 @@ kotlinx-serialization = "1.9.0"
 
 # Jackson / Serialization
 jackson = "2.20.1"
-jackson-databind-nullable = "0.2.6"
+jackson3 = "3.2.0"
+jackson-databind-nullable = "0.2.10"
 
 # OpenAPI
 kaizen-openapi-parser = "4.1.0"
@@ -59,6 +60,9 @@ jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations
 jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" }
 jackson-databind-nullable = { module = "org.openapitools:jackson-databind-nullable", version.ref = "jackson-databind-nullable" }
+jackson3-bom = { module = "tools.jackson:jackson-bom", version.ref = "jackson3" }
+jackson3-module-kotlin = { module = "tools.jackson.module:jackson-module-kotlin" }
+jackson3-databind = { module = "tools.jackson.core:jackson-databind" }
 
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "fabrikt"
 
 include(
     "end2end-tests:okhttp",
+    "end2end-tests:okhttp-jackson3",
     "end2end-tests:okhttp-multipart",
     "end2end-tests:okhttp-enhanced-multipart",
     "end2end-tests:okhttp-non-null",

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenOptions.kt
@@ -215,12 +215,16 @@ enum class SerializationLibrary(
     val description: String,
     val serializationAnnotations: SerializationAnnotations,
 ) {
-    JACKSON("Use Jackson for serialization and deserialization", JacksonAnnotations),
+    JACKSON("Use Jackson 2 for serialization and deserialization", JacksonAnnotations),
+    JACKSON_3("Use Jackson 3 for serialization and deserialization", JacksonAnnotations),
     KOTLINX_SERIALIZATION(
         "Use kotlinx.serialization for serialization and deserialization",
         KotlinxSerializationAnnotations,
     ),
     ;
+
+    val isJackson: Boolean
+        get() = this == JACKSON || this == JACKSON_3
 
     override fun toString() = "`${super.toString()}` - $description"
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/MutableSettings.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/MutableSettings.kt
@@ -66,7 +66,7 @@ object MutableSettings {
      * is used, returns [jacksonNullabilityMode], otherwise returns [JacksonNullabilityMode.NONE].
      */
     val effectiveJacksonNullabilityMode: JacksonNullabilityMode
-        get() = if (serializationLibrary == SerializationLibrary.JACKSON) jacksonNullabilityMode else JacksonNullabilityMode.NONE
+        get() = if (serializationLibrary.isJackson) jacksonNullabilityMode else JacksonNullabilityMode.NONE
 
     fun updateSettings(
         genTypes: Set<CodeGenerationType> = emptySet(),

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/ClientGeneratorUtils.kt
@@ -13,6 +13,7 @@ import com.cjbooms.fabrikt.generators.GeneratorUtils.toClassName
 import com.cjbooms.fabrikt.generators.GeneratorUtils.toIncomingParameters
 import com.cjbooms.fabrikt.generators.OasDefault
 import com.cjbooms.fabrikt.generators.controller.metadata.SpringImports.RESPONSE_ENTITY
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.JSON_NODE_CLASS
 import com.cjbooms.fabrikt.generators.model.ModelGenerator.Companion.toModelType
 import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.ClientType
@@ -24,7 +25,6 @@ import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.groupByPathSegment
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.routeToPathsByFirstTag
-import com.fasterxml.jackson.databind.JsonNode
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Path
 import com.squareup.kotlinpoet.AnnotationSpec
@@ -58,6 +58,7 @@ object ClientGeneratorUtils {
     fun Operation.getReturnType(packages: Packages): TypeName =
         when (val returnType = getReturnType()) {
             is KotlinTypeInfo -> toModelType(packages.base, returnType)
+            is TypeName -> returnType
             is KClass<*> -> returnType.asTypeName()
             else -> throw IllegalStateException("Unsupported return type: $returnType")
         }
@@ -70,7 +71,7 @@ object ClientGeneratorUtils {
         if (!hasAnySuccessResponseSchemas()) {
             Unit::class
         } else if (hasMultipleSuccessResponseSchemas()) {
-            if (hasOnlyJsonSuccessResponses()) JsonNode::class else Any::class
+            if (hasOnlyJsonSuccessResponses()) JSON_NODE_CLASS else Any::class
         } else {
             this.getPrimaryContentMediaType()?.let {
                 KotlinTypeInfo.from(it.value.schema)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpClientLibraryFiles.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpClientLibraryFiles.kt
@@ -1,6 +1,8 @@
 package com.cjbooms.fabrikt.generators.client
 
 import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.OBJECT_MAPPER_CLASS
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.TYPE_REFERENCE_CLASS
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -26,8 +28,11 @@ object OkHttpClientLibraryFiles {
     private val requestBody = ClassName("okhttp3", "RequestBody")
     private val response = ClassName("okhttp3", "Response")
     private val responseBody = ClassName("okhttp3", "ResponseBody")
-    private val objectMapper = ClassName("com.fasterxml.jackson.databind", "ObjectMapper")
-    private val typeReference = ClassName("com.fasterxml.jackson.core.type", "TypeReference")
+    private val objectMapper: ClassName
+        get() = OBJECT_MAPPER_CLASS
+
+    private val typeReference: ClassName
+        get() = TYPE_REFERENCE_CLASS
     private val runtimeException = ClassName("kotlin", "RuntimeException")
 
     private val suppressUnused = AnnotationSpec.builder(Suppress::class).addMember("%S", "unused").build()

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpEnhancedClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpEnhancedClientGenerator.kt
@@ -13,6 +13,7 @@ import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.enhancedClient
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.groupedClientPaths
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientName
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.toClientReturnType
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.OBJECT_MAPPER_CLASS
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.TYPE_REFERENCE_IMPORT
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.Destinations
@@ -20,7 +21,6 @@ import com.cjbooms.fabrikt.model.GeneratedFile
 import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.SimpleFile
 import com.cjbooms.fabrikt.model.SourceApi
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.javaparser.utils.CodeGenerationUtils
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.squareup.kotlinpoet.AnnotationSpec
@@ -123,7 +123,7 @@ class OkHttpEnhancedClientGenerator(
                                 circuitBreakerRegistryProperty.name,
                                 circuitBreakerRegistryProperty.type,
                             ).build(),
-                        ParameterSpec.builder("objectMapper", ObjectMapper::class.asTypeName()).build(),
+                        ParameterSpec.builder("objectMapper", OBJECT_MAPPER_CLASS).build(),
                         ParameterSpec.builder("baseUrl", String::class.asTypeName()).build(),
                         ParameterSpec.builder("okHttpClient", "OkHttpClient".toClassName("okhttp3")).build(),
                     ),

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -17,6 +17,7 @@ import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.getReturnType
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.groupedClientPaths
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientName
 import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.toClientReturnType
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.OBJECT_MAPPER_CLASS
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.TYPE_REFERENCE_IMPORT
 import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.ClientType
@@ -31,7 +32,6 @@ import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SimpleFile
 import com.cjbooms.fabrikt.model.SourceApi
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.javaparser.utils.CodeGenerationUtils
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.squareup.kotlinpoet.AnnotationSpec
@@ -104,7 +104,7 @@ class OkHttpSimpleClientGenerator(
                     TypeSpec
                         .classBuilder(simpleClientName(resourceName))
                         .primaryPropertiesConstructor(
-                            PropertySpec.builder("objectMapper", ObjectMapper::class.asTypeName(), KModifier.PRIVATE).build(),
+                            PropertySpec.builder("objectMapper", OBJECT_MAPPER_CLASS, KModifier.PRIVATE).build(),
                             PropertySpec.builder("baseUrl", String::class.asTypeName(), KModifier.PRIVATE).build(),
                             PropertySpec
                                 .builder("okHttpClient", "OkHttpClient".toClassName("okhttp3"), KModifier.PRIVATE)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerGeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/ControllerGeneratorUtils.kt
@@ -2,11 +2,11 @@ package com.cjbooms.fabrikt.generators.controller
 
 import com.cjbooms.fabrikt.generators.GeneratorUtils.hasMultipleSuccessResponseSchemas
 import com.cjbooms.fabrikt.generators.GeneratorUtils.hasOnlyJsonSuccessResponses
+import com.cjbooms.fabrikt.generators.model.JacksonMetadata.JSON_NODE_CLASS
 import com.cjbooms.fabrikt.generators.model.ModelGenerator.Companion.toModelType
 import com.cjbooms.fabrikt.model.ControllerType
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.util.NormalisedString.camelCase
-import com.fasterxml.jackson.databind.JsonNode
 import com.reprezen.kaizen.oasparser.model3.Operation
 import com.reprezen.kaizen.oasparser.model3.Response
 import com.reprezen.kaizen.oasparser.model3.SecurityRequirement
@@ -21,7 +21,7 @@ object ControllerGeneratorUtils {
         }
 
     private fun Operation.multiSchemaResponseType(): TypeName =
-        if (hasOnlyJsonSuccessResponses()) JsonNode::class.asTypeName() else Any::class.asTypeName()
+        if (hasOnlyJsonSuccessResponses()) JSON_NODE_CLASS else Any::class.asTypeName()
 
     private fun Operation.singleSchemaResponseType(basePackage: String): TypeName =
         primarySuccessResponse()

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonMetadata.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/JacksonMetadata.kt
@@ -1,5 +1,7 @@
 package com.cjbooms.fabrikt.generators.model
 
+import com.cjbooms.fabrikt.cli.SerializationLibrary
+import com.cjbooms.fabrikt.generators.MutableSettings
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.util.NormalisedString.pascalCase
 import com.cjbooms.fabrikt.util.toLowerCase
@@ -9,7 +11,45 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.TypeName
 
 object JacksonMetadata {
-    val TYPE_REFERENCE_IMPORT = Pair("com.fasterxml.jackson.module.kotlin", "jacksonTypeRef")
+    private const val JACKSON_2_DATABIND_PACKAGE = "com.fasterxml.jackson.databind"
+    private const val JACKSON_2_KOTLIN_PACKAGE = "com.fasterxml.jackson.module.kotlin"
+    private const val JACKSON_2_TYPE_REFERENCE_PACKAGE = "com.fasterxml.jackson.core.type"
+    private const val JACKSON_3_DATABIND_PACKAGE = "tools.jackson.databind"
+    private const val JACKSON_3_KOTLIN_PACKAGE = "tools.jackson.module.kotlin"
+    private const val JACKSON_3_TYPE_REFERENCE_PACKAGE = "tools.jackson.core.type"
+
+    private val isJackson3: Boolean
+        get() = MutableSettings.serializationLibrary == SerializationLibrary.JACKSON_3
+
+    val OBJECT_MAPPER_CLASS: ClassName
+        get() =
+            if (isJackson3) {
+                ClassName("$JACKSON_3_DATABIND_PACKAGE.json", "JsonMapper")
+            } else {
+                ClassName(JACKSON_2_DATABIND_PACKAGE, "ObjectMapper")
+            }
+
+    val JSON_NODE_CLASS: ClassName
+        get() =
+            ClassName(
+                if (isJackson3) JACKSON_3_DATABIND_PACKAGE else JACKSON_2_DATABIND_PACKAGE,
+                "JsonNode",
+            )
+
+    val TYPE_REFERENCE_IMPORT: Pair<String, String>
+        get() =
+            Pair(
+                if (isJackson3) JACKSON_3_KOTLIN_PACKAGE else JACKSON_2_KOTLIN_PACKAGE,
+                "jacksonTypeRef",
+            )
+
+    val TYPE_REFERENCE_CLASS: ClassName
+        get() =
+            ClassName(
+                if (isJackson3) JACKSON_3_TYPE_REFERENCE_PACKAGE else JACKSON_2_TYPE_REFERENCE_PACKAGE,
+                "TypeReference",
+            )
+
     private val JSON_PROPERTY_CLASS = ClassName("com.fasterxml.jackson.annotation", "JsonProperty")
     private val JSON_VALUE_CLASS = ClassName("com.fasterxml.jackson.annotation", "JsonValue")
     private val JSON_TYPE_INFO_CLASS = ClassName("com.fasterxml.jackson.annotation", "JsonTypeInfo")

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/Jackson3GeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/Jackson3GeneratorTest.kt
@@ -1,0 +1,121 @@
+package com.cjbooms.fabrikt.generators
+
+import com.cjbooms.fabrikt.cli.ClientCodeGenOptionType
+import com.cjbooms.fabrikt.cli.CodeGenerationType
+import com.cjbooms.fabrikt.cli.JacksonNullabilityMode
+import com.cjbooms.fabrikt.cli.SerializationLibrary
+import com.cjbooms.fabrikt.cli.SerializationLibraryOptionConverter
+import com.cjbooms.fabrikt.configurations.Packages
+import com.cjbooms.fabrikt.generators.client.OkHttpEnhancedClientGenerator
+import com.cjbooms.fabrikt.generators.client.OkHttpSimpleClientGenerator
+import com.cjbooms.fabrikt.generators.client.OpenFeignInterfaceGenerator
+import com.cjbooms.fabrikt.generators.controller.SpringControllerInterfaceGenerator
+import com.cjbooms.fabrikt.generators.model.ModelGenerator
+import com.cjbooms.fabrikt.model.SimpleFile
+import com.cjbooms.fabrikt.model.SourceApi
+import com.cjbooms.fabrikt.util.ModelNameRegistry
+import com.cjbooms.fabrikt.util.ResourceHelper.readTextResource
+import com.cjbooms.fabrikt.util.TestFileUtils.toSingleFile
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class Jackson3GeneratorTest {
+    private val packages = Packages("examples.jackson3")
+
+    private fun sourceApi() = SourceApi(readTextResource("/examples/multiMediaType/api.yaml"))
+
+    @BeforeEach
+    fun init() {
+        MutableSettings.updateSettings(
+            genTypes = setOf(CodeGenerationType.CLIENT),
+            serializationLibrary = SerializationLibrary.JACKSON_3,
+        )
+        ModelNameRegistry.clear()
+    }
+
+    @Test
+    fun `Jackson 2 remains the default serialization library`() {
+        assertThat(SerializationLibrary.default).isEqualTo(SerializationLibrary.JACKSON)
+    }
+
+    @Test
+    fun `Jackson 3 can be selected using the CLI value`() {
+        assertThat(SerializationLibraryOptionConverter().convert("jackson_3"))
+            .isEqualTo(SerializationLibrary.JACKSON_3)
+    }
+
+    @Test
+    fun `Jackson 3 models keep using the shared Jackson annotations`() {
+        val models = ModelGenerator(packages, sourceApi()).generate().toSingleFile()
+
+        assertThat(models)
+            .contains("import com.fasterxml.jackson.`annotation`.JsonProperty")
+            .doesNotContain("import tools.jackson.annotation")
+    }
+
+    @Test
+    fun `Jackson nullability modes also apply to Jackson 3`() {
+        MutableSettings.updateSettings(
+            serializationLibrary = SerializationLibrary.JACKSON_3,
+            jacksonNullabilityMode = JacksonNullabilityMode.STRICT,
+        )
+
+        assertThat(MutableSettings.effectiveJacksonNullabilityMode)
+            .isEqualTo(JacksonNullabilityMode.STRICT)
+    }
+
+    @Test
+    fun `Jackson 3 OkHttp clients use Jackson 3 runtime types`() {
+        val sourceApi = sourceApi()
+        val generator = OkHttpSimpleClientGenerator(packages, sourceApi)
+        val client = generator.generateDynamicClientCode().toSingleFile()
+        val httpUtil =
+            generator
+                .generateLibrary(emptySet())
+                .filterIsInstance<SimpleFile>()
+                .first { it.path.fileName.toString() == "HttpUtil.kt" }
+                .content
+        val enhancedClient =
+            OkHttpEnhancedClientGenerator(packages, sourceApi)
+                .generateDynamicClientCode(setOf(ClientCodeGenOptionType.RESILIENCE4J))
+                .toSingleFile()
+
+        assertThat(client)
+            .contains("import tools.jackson.databind.JsonNode")
+            .contains("import tools.jackson.databind.json.JsonMapper")
+            .contains("import tools.jackson.module.kotlin.jacksonTypeRef")
+            .doesNotContain("import com.fasterxml.jackson.databind")
+            .doesNotContain("import com.fasterxml.jackson.module.kotlin")
+        assertThat(httpUtil)
+            .contains("import tools.jackson.core.type.TypeReference")
+            .contains("import tools.jackson.databind.json.JsonMapper")
+            .doesNotContain("import com.fasterxml.jackson")
+        assertThat(enhancedClient)
+            .contains("import tools.jackson.databind.json.JsonMapper")
+            .contains("import tools.jackson.module.kotlin.jacksonTypeRef")
+    }
+
+    @Test
+    fun `Jackson 3 response types are used by interface generators`() {
+        val sourceApi = sourceApi()
+        val openFeignClient =
+            OpenFeignInterfaceGenerator(packages, sourceApi)
+                .generate(emptySet())
+                .clients
+                .toSingleFile()
+        val springController =
+            SpringControllerInterfaceGenerator(
+                packages,
+                sourceApi,
+                JavaxValidationAnnotations,
+            ).generate().files.joinToString("\n")
+
+        assertThat(openFeignClient)
+            .contains("import tools.jackson.databind.JsonNode")
+            .doesNotContain("import com.fasterxml.jackson.databind.JsonNode")
+        assertThat(springController)
+            .contains("import tools.jackson.databind.JsonNode")
+            .doesNotContain("import com.fasterxml.jackson.databind.JsonNode")
+    }
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -7,6 +7,7 @@ import com.cjbooms.fabrikt.cli.CodeGenerationType
 import com.cjbooms.fabrikt.cli.ExternalReferencesResolutionMode
 import com.cjbooms.fabrikt.cli.ModelCodeGenOptionType
 import com.cjbooms.fabrikt.cli.OutputOptionType
+import com.cjbooms.fabrikt.cli.SerializationLibrary
 import com.cjbooms.fabrikt.configurations.Packages
 import com.cjbooms.fabrikt.generators.client.OkHttpClientGenerator
 import com.cjbooms.fabrikt.generators.client.OkHttpEnhancedClientGenerator
@@ -36,6 +37,7 @@ class OkHttpClientGeneratorTest {
     private fun fullApiTestCases(): Stream<String> =
         Stream.of(
             "okHttpClient",
+            "jackson3",
             "multiMediaType",
             "okHttpClientPostWithoutRequestBody",
             "pathLevelParameters",
@@ -49,18 +51,24 @@ class OkHttpClientGeneratorTest {
 
     @BeforeEach
     fun init() {
+        updateSettings()
+        ModelNameRegistry.clear()
+    }
+
+    private fun updateSettings(serializationLibrary: SerializationLibrary = SerializationLibrary.default) {
         MutableSettings.updateSettings(
             genTypes = setOf(CodeGenerationType.CLIENT),
             clientTarget = ClientCodeGenTargetType.OK_HTTP,
             modelOptions = setOf(ModelCodeGenOptionType.X_EXTENSIBLE_ENUMS, ModelCodeGenOptionType.DISABLE_SEALED_INTERFACES_FOR_ONE_OF),
             typeOverrides = setOf(CodeGenTypeOverride.BYTEARRAY_AS_INPUTSTREAM),
+            serializationLibrary = serializationLibrary,
         )
-        ModelNameRegistry.clear()
     }
 
     @ParameterizedTest
     @MethodSource("groupedClientTestCases")
     fun `correct api simple client is generated from a full API definition`(testCaseName: String) {
+        configureSerializationLibrary(testCaseName)
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
         val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
@@ -91,6 +99,7 @@ class OkHttpClientGeneratorTest {
     @ParameterizedTest
     @MethodSource("groupedClientTestCases")
     fun `correct api fault-tolerant service client is generated when the resilience4j option is set`(testCaseName: String) {
+        configureSerializationLibrary(testCaseName)
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
         val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
@@ -117,6 +126,7 @@ class OkHttpClientGeneratorTest {
     @ParameterizedTest
     @MethodSource("fullApiTestCases")
     fun `the enhanced client is not generated when no specific options are provided`(testCaseName: String) {
+        configureSerializationLibrary(testCaseName)
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
         val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
@@ -133,6 +143,7 @@ class OkHttpClientGeneratorTest {
     @ParameterizedTest
     @MethodSource("fullApiTestCases")
     fun `correct client library files are generated`(testCaseName: String) {
+        configureSerializationLibrary(testCaseName)
         val packages = Packages("examples.$testCaseName")
         val apiLocation = javaClass.getResource("/examples/$testCaseName/api.yaml")!!
         val sourceApi = SourceApi(apiLocation.readText(), baseUri = apiLocation.toURI())
@@ -156,6 +167,12 @@ class OkHttpClientGeneratorTest {
 
     private fun optionsFor(testCaseName: String): Set<ClientCodeGenOptionType> =
         if (testCaseName == "tagGrouping") setOf(ClientCodeGenOptionType.GROUP_BY_TAG) else emptySet()
+
+    private fun configureSerializationLibrary(testCaseName: String) {
+        if (testCaseName == "jackson3") {
+            updateSettings(SerializationLibrary.JACKSON_3)
+        }
+    }
 
     private fun expectedClientPath(
         testCaseName: String,

--- a/src/test/resources/examples/jackson3/api.yaml
+++ b/src/test/resources/examples/jackson3/api.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.0
+info:
+  title: Jackson 3 example
+  version: 1.0.0
+paths:
+  /widgets:
+    get:
+      operationId: getWidgets
+      responses:
+        200:
+          description: Widget available
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Widget'
+        202:
+          description: Widget pending
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PendingWidget'
+    post:
+      operationId: createWidget
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Widget'
+      responses:
+        204:
+          description: Widget created
+components:
+  schemas:
+    Widget:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+    PendingWidget:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string

--- a/src/test/resources/examples/jackson3/client/ApiClient.kt
+++ b/src/test/resources/examples/jackson3/client/ApiClient.kt
@@ -1,0 +1,88 @@
+package examples.jackson3.client
+
+import examples.jackson3.models.Widget
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.jacksonTypeRef
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+@Suppress("unused")
+public class WidgetsClient(
+    private val objectMapper: JsonMapper,
+    private val baseUrl: String,
+    private val okHttpClient: OkHttpClient,
+) {
+    /**
+     *
+     */
+    @Throws(ApiException::class)
+    public fun getWidgets(
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<JsonNode> {
+        val httpUrl: HttpUrl =
+            "$baseUrl/widgets"
+                .toHttpUrl()
+                .newBuilder()
+                .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+                .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .headers(httpHeaders)
+                .get()
+                .build()
+
+        return request.execute(okHttpClient, objectMapper, jacksonTypeRef())
+    }
+
+    /**
+     *
+     *
+     * @param widget
+     */
+    @Throws(ApiException::class)
+    public fun createWidget(
+        widget: Widget,
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<Unit> {
+        val httpUrl: HttpUrl =
+            "$baseUrl/widgets"
+                .toHttpUrl()
+                .newBuilder()
+                .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+                .build()
+
+        val headerBuilder = Headers.Builder()
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .headers(httpHeaders)
+                .post(objectMapper.writeValueAsString(widget).toRequestBody("application/json".toMediaType()))
+                .build()
+
+        return request.execute(okHttpClient, objectMapper, jacksonTypeRef())
+    }
+}

--- a/src/test/resources/examples/jackson3/client/ApiModels.kt
+++ b/src/test/resources/examples/jackson3/client/ApiModels.kt
@@ -1,0 +1,51 @@
+package examples.jackson3.client
+
+import kotlin.Int
+import kotlin.RuntimeException
+import kotlin.String
+import okhttp3.Headers
+
+/**
+ * API 2xx success response returned by API call.
+ *
+ * @param <T> The type of data that is deserialized from response body
+ */
+public data class ApiResponse<T>(
+  public val statusCode: Int,
+  public val headers: Headers,
+  public val `data`: T? = null,
+)
+
+/**
+ * API non-2xx failure responses returned by API call.
+ */
+public open class ApiException(
+  override val message: String,
+) : RuntimeException(message)
+
+/**
+ * API 3xx redirect response returned by API call.
+ */
+public open class ApiRedirectException(
+  public val statusCode: Int,
+  public val headers: Headers,
+  override val message: String,
+) : ApiException(message)
+
+/**
+ * API 4xx failure responses returned by API call.
+ */
+public data class ApiClientException(
+  public val statusCode: Int,
+  public val headers: Headers,
+  override val message: String,
+) : ApiException(message)
+
+/**
+ * API 5xx failure responses returned by API call.
+ */
+public data class ApiServerException(
+  public val statusCode: Int,
+  public val headers: Headers,
+  override val message: String,
+) : ApiException(message)

--- a/src/test/resources/examples/jackson3/client/ApiService.kt
+++ b/src/test/resources/examples/jackson3/client/ApiService.kt
@@ -1,0 +1,48 @@
+package examples.jackson3.client
+
+import examples.jackson3.models.Widget
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import okhttp3.OkHttpClient
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.jacksonTypeRef
+import kotlin.String
+import kotlin.Suppress
+import kotlin.Unit
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+/**
+ * The circuit breaker registry should have the proper configuration to correctly action on circuit
+ * breaker transitions based on the client exceptions [ApiClientException], [ApiServerException] and
+ * [IOException].
+ *
+ * @see ApiClientException
+ * @see ApiServerException
+ */
+@Suppress("unused")
+public class WidgetsService(
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+    objectMapper: JsonMapper,
+    baseUrl: String,
+    okHttpClient: OkHttpClient,
+) {
+    public var circuitBreakerName: String = "widgetsClient"
+
+    private val apiClient: WidgetsClient = WidgetsClient(objectMapper, baseUrl, okHttpClient)
+
+    @Throws(ApiException::class)
+    public fun getWidgets(additionalHeaders: Map<String, String> = emptyMap()): ApiResponse<JsonNode> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.getWidgets(additionalHeaders)
+        }
+
+    @Throws(ApiException::class)
+    public fun createWidget(
+        widget: Widget,
+        additionalHeaders: Map<String, String> = emptyMap(),
+    ): ApiResponse<Unit> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.createWidget(widget, additionalHeaders)
+        }
+}

--- a/src/test/resources/examples/jackson3/client/HttpResilience4jUtil.kt
+++ b/src/test/resources/examples/jackson3/client/HttpResilience4jUtil.kt
@@ -1,0 +1,14 @@
+package examples.jackson3.client
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import kotlin.String
+
+public fun <T> withCircuitBreaker(
+  circuitBreakerRegistry: CircuitBreakerRegistry,
+  apiClientName: String,
+  apiCall: () -> ApiResponse<T>,
+): ApiResponse<T> {
+  val circuitBreaker = circuitBreakerRegistry.circuitBreaker(apiClientName)
+  return CircuitBreaker.decorateSupplier(circuitBreaker, apiCall).get()
+}

--- a/src/test/resources/examples/jackson3/client/HttpUtil.kt
+++ b/src/test/resources/examples/jackson3/client/HttpUtil.kt
@@ -1,0 +1,107 @@
+package examples.jackson3.client
+
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.ByteArray
+import kotlin.Pair
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.jvm.Throws
+import okhttp3.FormBody
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody
+import tools.jackson.core.type.TypeReference
+import tools.jackson.databind.json.JsonMapper
+
+@Suppress("unused")
+public fun <T : Any> HttpUrl.Builder.queryParam(key: String, `value`: T?): HttpUrl.Builder {
+  if (value != null) this.addQueryParameter(key, value.toString())
+  return this
+}
+
+@Suppress("unused")
+public fun <T : Any> FormBody.Builder.formParam(key: String, `value`: T?): FormBody.Builder {
+  if (value != null) this.add(key, value.toString())
+  return this
+}
+
+@Suppress("unused")
+public fun HttpUrl.Builder.queryParam(
+  key: String,
+  values: List<Any>?,
+  explode: Boolean = true,
+): HttpUrl.Builder {
+  if (values != null) {
+      if (explode) values.forEach { addQueryParameter(key, it.toString()) }
+      else addQueryParameter(key, values.joinToString(","))
+  }
+  return this
+}
+
+@Suppress("unused")
+public fun Headers.Builder.`header`(key: String, `value`: Any?): Headers.Builder {
+  if (value != null) this.add(key, value.toString())
+  return this
+}
+
+@Throws(ApiException::class)
+public fun <T> Request.execute(
+  client: OkHttpClient,
+  objectMapper: JsonMapper,
+  typeRef: TypeReference<T>,
+): ApiResponse<T> = doRequest(client) { responseBody ->
+  responseBody?.deserialize(objectMapper, typeRef)
+}
+
+@Throws(ApiException::class)
+public fun Request.execute(client: OkHttpClient): ApiResponse<ByteArray> =
+    doRequest(client) { responseBody ->
+  responseBody?.deserialize()
+}
+
+private fun <T> Request.doRequest(client: OkHttpClient, bodyReader: (ResponseBody?) -> T?):
+    ApiResponse<T> = client.newCall(this).execute().use { response ->
+  when {
+    response.isSuccessful ->
+      ApiResponse(response.code, response.headers, bodyReader(response.body))
+    response.isRedirection() ->
+      throw ApiRedirectException(response.code, response.headers, response.errorMessage())
+    response.isBadRequest() ->
+      throw ApiClientException(response.code, response.headers, response.errorMessage())
+    response.isServerError() ->
+      throw ApiServerException(response.code, response.headers, response.errorMessage())
+    else -> throw ApiException("[${response.code}]: ${response.errorMessage()}")
+  }
+}
+
+@Suppress("unused")
+public fun String.pathParam(vararg params: Pair<String, Any>): String =
+    params.fold(this) { acc, param ->
+  acc.replace(param.first, param.second.toString())
+}
+
+public fun <T> ResponseBody.deserialize(objectMapper: JsonMapper, typeRef: TypeReference<T>): T? =
+    this.string().isNotBlankOrNull()?.let { objectMapper.readValue(it, typeRef) }
+
+public fun ResponseBody.deserialize(): ByteArray? = this.byteStream().readAllBytes()
+
+public fun String?.isNotBlankOrNull(): String? = if (this.isNullOrBlank()) null else this
+
+private fun Response.errorMessage(): String = this.body?.string() ?: this.message
+
+private fun Response.isBadRequest(): Boolean = this.code in 400..499
+
+private fun Response.isServerError(): Boolean = this.code in 500..599
+
+private fun Response.isRedirection(): Boolean = this.code in 300..399
+
+public data class RequestBodyWithFilename(
+  public val requestBody: RequestBody,
+  public val filename: String,
+)

--- a/src/test/resources/examples/jackson3/client/OAuth.kt
+++ b/src/test/resources/examples/jackson3/client/OAuth.kt
@@ -1,0 +1,24 @@
+package examples.jackson3.client
+
+import kotlin.String
+import okhttp3.Authenticator
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+
+public class OAuth2(
+  public val accessToken: () -> String,
+) : Authenticator, Interceptor {
+  override fun authenticate(route: Route?, response: Response): Request =
+      response.request.newBuilder()
+              .header("Authorization", "Bearer ${accessToken().trim()}")
+              .build()
+
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val request = chain.request().newBuilder()
+      .header("Authorization", "Bearer ${accessToken().trim()}")
+      .build()
+    return chain.proceed(request)
+  }
+}

--- a/src/test/resources/examples/jackson3/models/ClientModels.kt
+++ b/src/test/resources/examples/jackson3/models/ClientModels.kt
@@ -1,0 +1,19 @@
+package examples.jackson3.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+
+public data class PendingWidget(
+    @param:JsonProperty("status")
+    @get:JsonProperty("status")
+    @get:NotNull
+    public val status: String,
+)
+
+public data class Widget(
+    @param:JsonProperty("id")
+    @get:JsonProperty("id")
+    @get:NotNull
+    public val id: String,
+)


### PR DESCRIPTION
Closes #556

## Summary

- Keep Jackson 2 as the default serialization library and add a new `JACKSON_3` option.
- Generate Jackson 3 runtime types and imports while retaining the shared Jackson 2 annotation package.
- Support Jackson 3 across OkHttp clients, enhanced clients, OpenFeign clients, Spring controllers, and generated model types that use Jackson runtime classes.
- Upgrade `jackson-databind-nullable` to 0.2.10 for Jackson 3 compatibility.
- Add generator, golden-file, and end-to-end coverage for Jackson 3, including `JsonNullable`.

## Compatibility

The default remains `JACKSON`, so existing users continue to receive Jackson 2 code. Jackson 3 generation is opt-in through `--serialization-library JACKSON_3`.

## Validation

- `./gradlew :test --tests com.cjbooms.fabrikt.generators.Jackson3GeneratorTest --tests com.cjbooms.fabrikt.generators.OkHttpClientGeneratorTest`
- `./gradlew :end2end-tests:okhttp-jackson3:test`
- `./gradlew ktlintCheck`
- Built and installed the artifact locally and successfully used the generated code in a real Spring Boot 4 migration.

A full clean build was also run on Windows. The only failures were existing platform-specific tests that assume a Unix `sh` executable or LF-only serialized output; all other root and subproject tests passed when those cases were excluded.

Development note: this implementation was created with assistance from OpenAI Codex and reviewed and validated by me.