### PR TITLE
refactor: introduce a version-aware OpenAPI parsing boundary

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/model/ModelGenerator.kt
@@ -32,6 +32,7 @@ import com.cjbooms.fabrikt.model.PropertyInfo.Companion.topLevelProperties
 import com.cjbooms.fabrikt.model.SchemaInfo
 import com.cjbooms.fabrikt.model.SerializationAnnotations
 import com.cjbooms.fabrikt.model.SourceApi
+import com.cjbooms.fabrikt.parser.KaizenParserAdapter
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.findOneOfSuperInterface
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.getDiscriminatorForInlinedObjectUnderAllOf
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.getSchemaRefName
@@ -59,7 +60,6 @@ import com.cjbooms.fabrikt.util.KaizenParserExtensions.safeName
 import com.cjbooms.fabrikt.util.ModelNameRegistry
 import com.cjbooms.fabrikt.util.NormalisedString.toEnumName
 import com.reprezen.jsonoverlay.Overlay
-import com.reprezen.kaizen.oasparser.OpenApi3Parser
 import com.reprezen.kaizen.oasparser.model3.Discriminator
 import com.reprezen.kaizen.oasparser.model3.OpenApi3
 import com.reprezen.kaizen.oasparser.model3.Schema
@@ -202,7 +202,7 @@ class ModelGenerator(
         val models: MutableSet<TypeSpec> = createModels(sourceApi.openApi3, sourceApi.allSchemas)
         externalApiSchemas.forEach { externalReferences ->
             val api =
-                OpenApi3Parser().parse(URL(externalReferences.key)).let { input ->
+                KaizenParserAdapter.parse(URL(externalReferences.key)).let { input ->
                     maybeConvertRelativeSchemaFile(externalReferences.key, input)
                 }
             val schemas =

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/SourceApi.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/SourceApi.kt
@@ -1,6 +1,7 @@
 package com.cjbooms.fabrikt.model
 
 import com.beust.jcommander.ParameterException
+import com.cjbooms.fabrikt.parser.OpenApiDocumentParser
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isEnumDefinition
 import com.cjbooms.fabrikt.util.KaizenParserExtensions.isNotDefined
 import com.cjbooms.fabrikt.util.ModelNameRegistry
@@ -43,7 +44,8 @@ class SourceApi private constructor(
         }
     }
 
-    val openApi3: OpenApi3 = YamlUtils.parseOpenApi(rawApiSpec, baseUri, jsonLoader)
+    internal val parsedDocument = OpenApiDocumentParser.parse(rawApiSpec, baseUri, jsonLoader)
+    val openApi3: OpenApi3 = parsedDocument.kaizenModel
     val allSchemas: List<SchemaInfo>
 
     init {

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/KaizenParserAdapter.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/KaizenParserAdapter.kt
@@ -1,0 +1,17 @@
+package com.cjbooms.fabrikt.parser
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.reprezen.jsonoverlay.JsonLoader
+import com.reprezen.kaizen.oasparser.OpenApi3Parser
+import com.reprezen.kaizen.oasparser.model3.OpenApi3
+import java.net.URL
+
+internal object KaizenParserAdapter {
+    fun parse(
+        input: JsonNode,
+        baseUrl: URL,
+        jsonLoader: JsonLoader?,
+    ): OpenApi3 = OpenApi3Parser().parse(input, baseUrl, false, jsonLoader) as OpenApi3
+
+    fun parse(url: URL): OpenApi3 = OpenApi3Parser().parse(url)
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParser.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParser.kt
@@ -1,0 +1,36 @@
+package com.cjbooms.fabrikt.parser
+
+import com.cjbooms.fabrikt.util.OpenApi31Downgrader
+import com.cjbooms.fabrikt.util.YamlObjectMapper
+import com.reprezen.jsonoverlay.JsonLoader
+import com.reprezen.kaizen.oasparser.OpenApi3Parser
+import com.reprezen.kaizen.oasparser.model3.OpenApi3
+import java.net.URI
+import java.nio.file.Paths
+
+internal class ParsedOpenApiDocument(
+    val sourceContent: String,
+    val kaizenModel: OpenApi3,
+)
+
+internal object OpenApiDocumentParser {
+    fun parse(
+        input: String,
+        baseUri: URI = Paths.get("").toAbsolutePath().toUri(),
+        jsonLoader: JsonLoader? = null,
+    ): ParsedOpenApiDocument =
+        try {
+            val kaizenInput = YamlObjectMapper.instance.readTree(input)
+            OpenApi31Downgrader.downgradeIncompatibleElements(kaizenInput)
+            OpenApiInputCleaner.cleanEmptyTypes(kaizenInput)
+            val kaizenModel = OpenApi3Parser().parse(kaizenInput, baseUri.toURL(), false, jsonLoader) as OpenApi3
+            ParsedOpenApiDocument(input, kaizenModel)
+        } catch (ex: NullPointerException) {
+            throw IllegalArgumentException(
+                "The Kaizen openapi-parser library threw a NPE exception when parsing this API. " +
+                    "This is commonly due to an external schema reference that is unresolvable, " +
+                    "possibly due to a lack of internet connection",
+                ex,
+            )
+        }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParser.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParser.kt
@@ -7,7 +7,7 @@ import com.reprezen.kaizen.oasparser.model3.OpenApi3
 import java.net.URI
 import java.nio.file.Paths
 
-internal class ParsedOpenApiDocument(
+internal data class ParsedOpenApiDocument(
     val sourceContent: String,
     val version: OpenApiVersion?,
     val kaizenModel: OpenApi3,

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParser.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParser.kt
@@ -3,13 +3,13 @@ package com.cjbooms.fabrikt.parser
 import com.cjbooms.fabrikt.util.OpenApi31Downgrader
 import com.cjbooms.fabrikt.util.YamlObjectMapper
 import com.reprezen.jsonoverlay.JsonLoader
-import com.reprezen.kaizen.oasparser.OpenApi3Parser
 import com.reprezen.kaizen.oasparser.model3.OpenApi3
 import java.net.URI
 import java.nio.file.Paths
 
 internal class ParsedOpenApiDocument(
     val sourceContent: String,
+    val version: OpenApiVersion?,
     val kaizenModel: OpenApi3,
 )
 
@@ -21,10 +21,11 @@ internal object OpenApiDocumentParser {
     ): ParsedOpenApiDocument =
         try {
             val kaizenInput = YamlObjectMapper.instance.readTree(input)
+            val version = OpenApiVersion.parse(kaizenInput["openapi"]?.asText())
             OpenApi31Downgrader.downgradeIncompatibleElements(kaizenInput)
             OpenApiInputCleaner.cleanEmptyTypes(kaizenInput)
-            val kaizenModel = OpenApi3Parser().parse(kaizenInput, baseUri.toURL(), false, jsonLoader) as OpenApi3
-            ParsedOpenApiDocument(input, kaizenModel)
+            val kaizenModel = KaizenParserAdapter.parse(kaizenInput, baseUri.toURL(), jsonLoader)
+            ParsedOpenApiDocument(input, version, kaizenModel)
         } catch (ex: NullPointerException) {
             throw IllegalArgumentException(
                 "The Kaizen openapi-parser library threw a NPE exception when parsing this API. " +

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiInputCleaner.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiInputCleaner.kt
@@ -1,0 +1,25 @@
+package com.cjbooms.fabrikt.parser
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+
+internal object OpenApiInputCleaner {
+    fun cleanEmptyTypes(node: JsonNode) {
+        when {
+            node.isObject -> {
+                val objectNode = node as ObjectNode
+                val fieldsToProcess = objectNode.fields().asSequence().toList()
+
+                for ((key, value) in fieldsToProcess) {
+                    if (key == "type" && (value.isNull || (value.isTextual && value.asText().isBlank()))) {
+                        objectNode.remove("type")
+                    } else {
+                        cleanEmptyTypes(value)
+                    }
+                }
+            }
+
+            node.isArray -> node.forEach { cleanEmptyTypes(it) }
+        }
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiVersion.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiVersion.kt
@@ -1,0 +1,22 @@
+package com.cjbooms.fabrikt.parser
+
+internal data class OpenApiVersion(
+    val value: String,
+    val major: Int,
+    val minor: Int,
+    val patch: Int?,
+) {
+    companion object {
+        private val versionPattern = Regex("""^(\d+)\.(\d+)(?:\.(\d+))?(?:[-+].*)?$""")
+
+        fun parse(value: String?): OpenApiVersion? {
+            val match = value?.let(versionPattern::matchEntire) ?: return null
+            return OpenApiVersion(
+                value = value,
+                major = match.groupValues[1].toInt(),
+                minor = match.groupValues[2].toInt(),
+                patch = match.groupValues[3].takeIf(String::isNotEmpty)?.toInt(),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/OpenApi31Downgrader.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/OpenApi31Downgrader.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
  * This is needed because some OpenAPI 3.1 features are not supported by the kaizen parser.
  */
 object OpenApi31Downgrader {
-    private val NULL_TYPE: JsonNode = YamlUtils.objectMapper.valueToTree("null")
+    private val NULL_TYPE: JsonNode = YamlObjectMapper.instance.valueToTree("null")
     private const val TARGET_MAJOR = 3
     private const val TARGET_MINOR = 0
 
@@ -45,7 +45,7 @@ object OpenApi31Downgrader {
                 if (objectNode.get("type")?.asText() == "array" && !objectNode.has("items")) {
                     objectNode.set<JsonNode>(
                         "items",
-                        YamlUtils.objectMapper.createObjectNode().apply {
+                        YamlObjectMapper.instance.createObjectNode().apply {
                             put("nullable", true)
                         },
                     )

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/YamlObjectMapper.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/YamlObjectMapper.kt
@@ -1,0 +1,29 @@
+package com.cjbooms.fabrikt.util
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.yaml.snakeyaml.LoaderOptions
+
+internal object YamlObjectMapper {
+    val instance: ObjectMapper =
+        ObjectMapper(
+            YAMLFactory
+                .builder()
+                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+                .increaseMaxFileSize()
+                .build(),
+        ).registerKotlinModule()
+            .configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
+}
+
+internal fun YAMLFactoryBuilder.increaseMaxFileSize(): YAMLFactoryBuilder =
+    loaderOptions(
+        LoaderOptions().apply {
+            codePointLimit = 100 * 1024 * 1024 // 100MB
+        },
+    )

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/YamlUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/YamlUtils.kt
@@ -1,16 +1,14 @@
 package com.cjbooms.fabrikt.util
 
-import com.fasterxml.jackson.core.JsonParser
+import com.cjbooms.fabrikt.parser.OpenApiDocumentParser
+import com.cjbooms.fabrikt.parser.OpenApiInputCleaner
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.reprezen.jsonoverlay.JsonLoader
-import com.reprezen.kaizen.oasparser.OpenApi3Parser
 import com.reprezen.kaizen.oasparser.model3.OpenApi3
 import org.yaml.snakeyaml.DumperOptions
 import org.yaml.snakeyaml.LoaderOptions
@@ -19,16 +17,7 @@ import java.net.URI
 import java.nio.file.Paths
 
 object YamlUtils {
-    val objectMapper: ObjectMapper =
-        ObjectMapper(
-            YAMLFactory
-                .builder()
-                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
-                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
-                .increaseMaxFileSize()
-                .build(),
-        ).registerKotlinModule()
-            .configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true)
+    val objectMapper: ObjectMapper = YamlObjectMapper.instance
     private val internalMapper: ObjectMapper =
         ObjectMapper(
             YAMLFactory
@@ -36,13 +25,6 @@ object YamlUtils {
                 .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
                 .increaseMaxFileSize()
                 .build(),
-        )
-
-    private fun YAMLFactoryBuilder.increaseMaxFileSize(): YAMLFactoryBuilder =
-        loaderOptions(
-            LoaderOptions().apply {
-                codePointLimit = 100 * 1024 * 1024 // 100MB
-            },
         )
 
     /**
@@ -94,41 +76,9 @@ object YamlUtils {
         input: String,
         baseUri: URI = Paths.get("").toAbsolutePath().toUri(),
         jsonLoader: JsonLoader? = null,
-    ): OpenApi3 =
-        try {
-            val root: JsonNode = objectMapper.readTree(input)
-            OpenApi31Downgrader.downgradeIncompatibleElements(root)
-            cleanEmptyTypes(root)
-            OpenApi3Parser().parse(root, baseUri.toURL(), false, jsonLoader) as OpenApi3
-        } catch (ex: NullPointerException) {
-            throw IllegalArgumentException(
-                "The Kaizen openapi-parser library threw a NPE exception when parsing this API. " +
-                    "This is commonly due to an external schema reference that is unresolvable, " +
-                    "possibly due to a lack of internet connection",
-                ex,
-            )
-        }
+    ): OpenApi3 = OpenApiDocumentParser.parse(input, baseUri, jsonLoader).kaizenModel
 
-    fun cleanEmptyTypes(node: JsonNode) {
-        when {
-            node.isObject -> {
-                val objectNode = node as ObjectNode
-                val fieldsToProcess = objectNode.fields().asSequence().toList()
-
-                for ((key, value) in fieldsToProcess) {
-                    if (key == "type" && (value.isNull || (value.isTextual && value.asText().isBlank()))) {
-                        objectNode.remove("type")
-                    } else {
-                        cleanEmptyTypes(value)
-                    }
-                }
-            }
-
-            node.isArray -> {
-                node.forEach { cleanEmptyTypes(it) }
-            }
-        }
-    }
+    fun cleanEmptyTypes(node: JsonNode) = OpenApiInputCleaner.cleanEmptyTypes(node)
 
     /**
      * The below merge function has been shamelessly stolen from Stackoverflow: https://stackoverflow.com/a/32447591/1026785

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/KaizenParserAdapterTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/KaizenParserAdapterTest.kt
@@ -1,0 +1,32 @@
+package com.cjbooms.fabrikt.parser
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class KaizenParserAdapterTest {
+    @Test
+    fun `parses an external OpenAPI document from its URL`(
+        @TempDir tempDir: Path,
+    ) {
+        val document =
+            """
+            openapi: 3.0.0
+            info:
+              title: External models
+              version: "1.0"
+            paths: {}
+            components:
+              schemas:
+                ExternalModel:
+                  type: object
+            """.trimIndent()
+        val documentPath = Files.writeString(tempDir.resolve("external.yaml"), document)
+
+        val api = KaizenParserAdapter.parse(documentPath.toUri().toURL())
+
+        assertThat(api.schemas).containsKey("ExternalModel")
+    }
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParserTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParserTest.kt
@@ -1,0 +1,33 @@
+package com.cjbooms.fabrikt.parser
+
+import com.cjbooms.fabrikt.util.YamlUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OpenApiDocumentParserTest {
+    @Test
+    fun `preserves the source document before applying Kaizen compatibility transformations`() {
+        val input =
+            """
+            openapi: 3.1.0
+            info:
+              title: Test
+              version: "1.0"
+            paths: {}
+            components:
+              schemas:
+                Name:
+                  type:
+                    - string
+                    - "null"
+            """.trimIndent()
+
+        val parsedDocument = OpenApiDocumentParser.parse(input)
+        val source = YamlUtils.objectMapper.readTree(parsedDocument.sourceContent)
+
+        assertThat(source.at("/components/schemas/Name/type").map { it.textValue() })
+            .containsExactly("string", "null")
+        assertThat(parsedDocument.kaizenModel.schemas["Name"]!!.type).isEqualTo("string")
+        assertThat(parsedDocument.kaizenModel.schemas["Name"]!!.nullable).isTrue()
+    }
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParserTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParserTest.kt
@@ -3,6 +3,8 @@ package com.cjbooms.fabrikt.parser
 import com.cjbooms.fabrikt.util.YamlUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 
 class OpenApiDocumentParserTest {
     @Test
@@ -29,5 +31,32 @@ class OpenApiDocumentParserTest {
             .containsExactly("string", "null")
         assertThat(parsedDocument.kaizenModel.schemas["Name"]!!.type).isEqualTo("string")
         assertThat(parsedDocument.kaizenModel.schemas["Name"]!!.nullable).isTrue()
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "3.0.4, 3, 0, 4",
+        "3.1.2, 3, 1, 2",
+        "3.2.0, 3, 2, 0",
+    )
+    fun `exposes the source OpenAPI version before compatibility transformations`(
+        value: String,
+        major: Int,
+        minor: Int,
+        patch: Int,
+    ) {
+        val input =
+            """
+            openapi: $value
+            info:
+              title: Test
+              version: "1.0"
+            paths: {}
+            """.trimIndent()
+
+        val version = OpenApiDocumentParser.parse(input).version
+
+        assertThat(version)
+            .isEqualTo(OpenApiVersion(value, major, minor, patch))
     }
 }


### PR DESCRIPTION
## Summary

Introduce an internal, version-aware boundary for parsing OpenAPI documents while preserving the existing Kaizen-based generation pipeline and generated output.

This is the first incremental step discussed in #656. It creates a place where Fabrikt can retain information from newer OpenAPI specifications before compatibility transformations are applied.

## Changes

- Add an internal `ParsedOpenApiDocument` that retains the original source alongside the existing Kaizen model.
- Capture the OpenAPI version before applying compatibility transformations.
- Recognize OpenAPI 3.0, 3.1 and 3.2 version strings without changing generation behavior.
- Move direct `OpenApi3Parser` usage behind a dedicated Kaizen parser adapter.
- Route external OpenAPI documents loaded during model generation through the same adapter.
- Extract the shared YAML mapper and input-cleanup logic to avoid coupling and dependency cycles.
- Keep the existing `YamlUtils` API and downstream generator APIs unchanged.

## Motivation

Fabrikt currently applies compatibility transformations before passing documents to Kaizen. Some valid OpenAPI 3.1 information, such as multi-type declarations containing `null`, is consequently no longer available to later processing stages.

Preserving the source document and its version gives future changes access to that information while allowing the existing Kaizen model to remain in use during an incremental migration.

This PR deliberately does not change generated code or claim OpenAPI 3.1/3.2 generation support. Functional support can be added in separate, focused PRs once the required source model and processing stages are introduced.

## Testing

- Added coverage showing that an OpenAPI 3.1 nullable type array remains present in the retained source while the existing Kaizen compatibility representation is unchanged.
- Added version-detection coverage for OpenAPI 3.0, 3.1 and 3.2 documents.
- Added coverage for parsing external OpenAPI documents through the Kaizen adapter.
- Verified that the complete Gradle build passes.
- Verified that existing generated examples remain unchanged.

Related to #656.