### PR TITLE
docs: update outdated project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ fabrikt {
 
 ### Maven
 
-The [exec-maven-plugin](http://www.mojohaus.org/exec-maven-plugin/examples/example-exec-using-plugin-dependencies.html) is capable of downloading the Fabrikt library from Maven Central and executing its main method with defined arguments.
+The [exec-maven-plugin](https://www.mojohaus.org/exec-maven-plugin/examples/example-exec-using-plugin-dependencies.html) is capable of downloading the Fabrikt library from Maven Central and executing its main method with defined arguments.
 
 ### Docker
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Fabrikt is a build-time code generation tool — it is not deployed as a runtime
 
 ## Supported Versions
 
-The latest release on [Maven Central](https://central.sonatype.com/artifact/com.cjbooms/fabrikt) is the only supported version.
+The latest release on [Maven Central](https://central.sonatype.com/artifact/io.fabrikt/fabrikt) is the only supported version.
 
 ## Reporting a Vulnerability
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,7 @@ tasks {
         }
         archiveBaseName.set(executableName)
         archiveClassifier.set("")
-        // relocate the transitive dependency on an old guava version to prevent conflicts (https://github.com/cjbooms/fabrikt/issues/379)
+        // relocate the transitive dependency on an old guava version to prevent conflicts (https://github.com/fabrikt-io/fabrikt/issues/379)
         relocate("com.google.common", "com.cjbooms.fabrikt.shaded.com.google.common")
         relocate("com.google.thirdparty", "com.cjbooms.fabrikt.shaded.com.google.thirdparty")
     }


### PR DESCRIPTION
## Summary

Update a small set of outdated project and dependency links across the repository.

No separate issue was opened for this change because it is a small, self-contained documentation correction with no functional impact.

## Changes

- Point the Security Policy to the current `io.fabrikt:fabrikt` artifact on Maven Central.
- Update the Maven Exec Plugin documentation link to use HTTPS.
- Update the reference to issue 379 from the old `cjbooms/fabrikt` repository path to `fabrikt-io/fabrikt`.

No functional code, dependencies or generated output are changed.

## Verification

- Verified that the updated links resolve successfully.
- Scanned the repository for similar outdated Maven Central, Sonatype, Bintray, JCenter and repository links.
- Ran the complete build successfully with:

```shell
./gradlew build
```