### PR TITLE
fix: bound duplicate model name suffixes

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/util/ModelNameRegistry.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/ModelNameRegistry.kt
@@ -30,14 +30,9 @@ object ModelNameRegistry {
         allocate: Boolean = true,
     ): String {
         val modelClassName = schema.toModelClassName(schemaInfoName, enclosingSchema, valueSuffix)
-        var suggestion = modelClassName
+        val suggestion = if (allocate) allocateUniqueName(modelClassName) else modelClassName
 
         if (allocate) {
-            while (allocatedNames.contains(suggestion)) {
-                suggestion += SUFFIX
-            }
-            allocatedNames.add(suggestion)
-
             val tag = resolveTag(schema, modelClassName)
             val replaced = tagToName.put(tag, suggestion)
             if (replaced != null) {
@@ -47,6 +42,18 @@ object ModelNameRegistry {
         }
 
         return suggestion
+    }
+
+    private fun allocateUniqueName(modelClassName: String): String {
+        if (allocatedNames.add(modelClassName)) return modelClassName
+
+        var collisionIndex = 1
+        while (true) {
+            val numericSuffix = if (collisionIndex == 1) "" else collisionIndex.toString()
+            val suggestion = "$modelClassName$SUFFIX$numericSuffix"
+            if (allocatedNames.add(suggestion)) return suggestion
+            collisionIndex++
+        }
     }
 
     private fun Schema.toModelClassName(
@@ -113,12 +120,7 @@ object ModelNameRegistry {
         val ref = Overlay.of(schema).jsonReference
         if (!referenceToName.containsKey(ref)) {
             val modelClassName = name.toModelClassName() + MutableSettings.modelSuffix
-            var suggestion = modelClassName
-            while (allocatedNames.contains(suggestion)) {
-                suggestion += SUFFIX
-            }
-            allocatedNames.add(suggestion)
-            referenceToName[ref] = suggestion
+            referenceToName[ref] = allocateUniqueName(modelClassName)
         }
     }
 

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/ModelGeneratorTest.kt
@@ -44,6 +44,7 @@ class ModelGeneratorTest {
             "arrays",
             "anyOfOneOfAllOf",
             "deepNestedSharingReferences",
+            "boundedModelNameCollisions",
             "defaultValues",
             "duplicatePropertyHandling",
             "enumExamples",

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -40,6 +40,7 @@ class SpringControllerGeneratorTest {
     private fun testCases(): Stream<String> =
         Stream.of(
             "arrays",
+            "boundedModelNameCollisions",
             "githubApi",
             "singleAllOf",
             "pathLevelParameters",

--- a/src/test/resources/examples/boundedModelNameCollisions/api.yaml
+++ b/src/test/resources/examples/boundedModelNameCollisions/api.yaml
@@ -1,0 +1,53 @@
+openapi: "3.0.0"
+info:
+  title: "Bounded Model Name Collisions"
+  version: "1.0.0"
+paths:
+  /a:
+    get:
+      operationId: getA
+      parameters:
+        - name: $select
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - Alpha
+                - Beta
+      responses:
+        200:
+          description: "ok"
+  /b:
+    get:
+      operationId: getB
+      parameters:
+        - name: $select
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - Gamma
+                - Delta
+      responses:
+        200:
+          description: "ok"
+  /c:
+    get:
+      operationId: getC
+      parameters:
+        - name: $select
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - Epsilon
+                - Zeta
+      responses:
+        200:
+          description: "ok"

--- a/src/test/resources/examples/boundedModelNameCollisions/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/boundedModelNameCollisions/controllers/spring/Controllers.kt
@@ -1,0 +1,75 @@
+package examples.boundedModelNameCollisions.controllers
+
+import examples.boundedModelNameCollisions.models.Select
+import examples.boundedModelNameCollisions.models.SelectExtra
+import examples.boundedModelNameCollisions.models.SelectExtra2
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.`annotation`.Validated
+import org.springframework.web.bind.`annotation`.RequestMapping
+import org.springframework.web.bind.`annotation`.RequestMethod
+import org.springframework.web.bind.`annotation`.RequestParam
+import javax.validation.Valid
+import kotlin.Unit
+import kotlin.collections.List
+
+@Controller
+@Validated
+@RequestMapping("")
+public interface AController {
+    /**
+     *
+     *
+     * @param select
+     */
+    @RequestMapping(
+        value = ["/a"],
+        produces = [],
+        method = [RequestMethod.GET],
+    )
+    public fun getA(
+        @Valid @RequestParam(value = "${'$'}select", required = false)
+        select: List<Select>?,
+    ): ResponseEntity<Unit>
+}
+
+@Controller
+@Validated
+@RequestMapping("")
+public interface BController {
+    /**
+     *
+     *
+     * @param select
+     */
+    @RequestMapping(
+        value = ["/b"],
+        produces = [],
+        method = [RequestMethod.GET],
+    )
+    public fun getB(
+        @Valid @RequestParam(value = "${'$'}select", required = false)
+        select: List<SelectExtra>?,
+    ): ResponseEntity<Unit>
+}
+
+@Controller
+@Validated
+@RequestMapping("")
+public interface CController {
+    /**
+     *
+     *
+     * @param select
+     */
+    @RequestMapping(
+        value = ["/c"],
+        produces = [],
+        method = [RequestMethod.GET],
+    )
+    public fun getC(
+        @Valid @RequestParam(value = "${'$'}select", required = false)
+        select: List<SelectExtra2>?,
+    ): ResponseEntity<Unit>
+}

--- a/src/test/resources/examples/boundedModelNameCollisions/models/Select.kt
+++ b/src/test/resources/examples/boundedModelNameCollisions/models/Select.kt
@@ -1,0 +1,22 @@
+package examples.boundedModelNameCollisions.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class Select(
+  @JsonValue
+  public val `value`: String,
+) {
+  ALPHA("Alpha"),
+  BETA("Beta"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, Select> = entries.associateBy(Select::value)
+
+    public fun fromValue(`value`: String): Select? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/boundedModelNameCollisions/models/SelectExtra.kt
+++ b/src/test/resources/examples/boundedModelNameCollisions/models/SelectExtra.kt
@@ -1,0 +1,22 @@
+package examples.boundedModelNameCollisions.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class SelectExtra(
+  @JsonValue
+  public val `value`: String,
+) {
+  GAMMA("Gamma"),
+  DELTA("Delta"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, SelectExtra> = entries.associateBy(SelectExtra::value)
+
+    public fun fromValue(`value`: String): SelectExtra? = mapping[value]
+  }
+}

--- a/src/test/resources/examples/boundedModelNameCollisions/models/SelectExtra2.kt
+++ b/src/test/resources/examples/boundedModelNameCollisions/models/SelectExtra2.kt
@@ -1,0 +1,22 @@
+package examples.boundedModelNameCollisions.models
+
+import com.fasterxml.jackson.`annotation`.JsonValue
+import kotlin.String
+import kotlin.collections.Map
+
+public enum class SelectExtra2(
+  @JsonValue
+  public val `value`: String,
+) {
+  EPSILON("Epsilon"),
+  ZETA("Zeta"),
+  ;
+
+  override fun toString(): String = value
+
+  public companion object {
+    private val mapping: Map<String, SelectExtra2> = entries.associateBy(SelectExtra2::value)
+
+    public fun fromValue(`value`: String): SelectExtra2? = mapping[value]
+  }
+}


### PR DESCRIPTION
## Summary

- Centralize unique model-name allocation in `ModelNameRegistry`.
- Preserve `Extra` for the first name collision and use numeric suffixes for subsequent collisions.
- Add model and Spring controller regression coverage based on the reproduction from #622.

## Motivation

Fabrikt currently resolves repeated model-name collisions by continually appending `Extra`, producing names such as:

```text
Select
SelectExtra
SelectExtraExtra
SelectExtraExtraExtra
```

For APIs containing many repeated inline enum query parameters, this can eventually exceed filesystem filename limits.

The new allocation sequence is bounded:

```text
Select
SelectExtra
SelectExtra2
SelectExtra3
```

Both regular schema registration and reference-based pre-registration now use the same allocation function.

## Compatibility

The existing base name and first collision remain unchanged as `Foo` and `FooExtra`. Numeric suffixes are introduced only for subsequent collisions, limiting generated-output changes to scenarios affected by the bug.

No unrelated golden files were changed.

## Testing

- Added a minimal specification with three `$select` array query parameters containing different inline enums.
- Added golden model coverage for `Select`, `SelectExtra`, and `SelectExtra2`.
- Added Spring controller coverage verifying that each parameter references the correct generated enum.
- Ran the targeted model and controller generator tests.
- Ran the complete clean build, including all end-to-end projects.

Development note: this implementation was prepared with assistance from OpenAI Codex and reviewed and validated by me.

Fixes #622