### PR TITLE
Refactor OpenAPI parsing to preserve recursive source schemas

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParser.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParser.kt
@@ -1,17 +1,18 @@
 package com.cjbooms.fabrikt.parser
 
 import com.cjbooms.fabrikt.util.OpenApi31Downgrader
-import com.cjbooms.fabrikt.util.YamlObjectMapper
+import com.fasterxml.jackson.databind.JsonNode
 import com.reprezen.jsonoverlay.JsonLoader
 import com.reprezen.kaizen.oasparser.model3.OpenApi3
 import java.net.URI
 import java.nio.file.Paths
 
 internal data class ParsedOpenApiDocument(
-    val sourceContent: String,
-    val version: OpenApiVersion?,
+    val source: SourceOpenApiDocument,
     val kaizenModel: OpenApi3,
-)
+) {
+    val version: OpenApiVersion? = source.version
+}
 
 internal object OpenApiDocumentParser {
     fun parse(
@@ -20,12 +21,12 @@ internal object OpenApiDocumentParser {
         jsonLoader: JsonLoader? = null,
     ): ParsedOpenApiDocument =
         try {
-            val kaizenInput = YamlObjectMapper.instance.readTree(input)
-            val version = OpenApiVersion.parse(kaizenInput["openapi"]?.asText())
+            val source = SourceOpenApiDocumentParser.parse(input)
+            val kaizenInput = source.root.deepCopy<JsonNode>()
             OpenApi31Downgrader.downgradeIncompatibleElements(kaizenInput)
             OpenApiInputCleaner.cleanEmptyTypes(kaizenInput)
             val kaizenModel = KaizenParserAdapter.parse(kaizenInput, baseUri.toURL(), jsonLoader)
-            ParsedOpenApiDocument(input, version, kaizenModel)
+            ParsedOpenApiDocument(source, kaizenModel)
         } catch (ex: NullPointerException) {
             throw IllegalArgumentException(
                 "The Kaizen openapi-parser library threw a NPE exception when parsing this API. " +

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
@@ -47,8 +47,50 @@ internal object SourceOpenApiDocumentParser {
                 node = node,
                 types = readTypes(node, version),
                 reference = node["\$ref"]?.takeIf(JsonNode::isTextual)?.textValue(),
+                properties = readNamedSchemas(node["properties"], "$location/properties", version),
+                items = readOptionalSchema(node["items"], "$location/items", version),
+                allOf = readSchemaList(node["allOf"], "$location/allOf", version),
+                anyOf = readSchemaList(node["anyOf"], "$location/anyOf", version),
+                oneOf = readSchemaList(node["oneOf"], "$location/oneOf", version),
+                not = readOptionalSchema(node["not"], "$location/not", version),
+                additionalProperties =
+                    readOptionalSchema(
+                        node["additionalProperties"],
+                        "$location/additionalProperties",
+                        version,
+                    ),
             )
         }
+
+    private fun readNamedSchemas(
+        node: JsonNode?,
+        location: String,
+        version: OpenApiVersion?,
+    ): Map<String, SourceSchema> {
+        if (node?.isObject != true) return emptyMap()
+
+        return node.properties().associate { (name, schema) ->
+            name to readSchema(schema, "$location/${name.toJsonPointerToken()}", version)
+        }
+    }
+
+    private fun readOptionalSchema(
+        node: JsonNode?,
+        location: String,
+        version: OpenApiVersion?,
+    ): SourceSchema? = node?.takeIf { it.isObject || it.isBoolean }?.let { readSchema(it, location, version) }
+
+    private fun readSchemaList(
+        node: JsonNode?,
+        location: String,
+        version: OpenApiVersion?,
+    ): List<SourceSchema> {
+        if (node?.isArray != true) return emptyList()
+
+        return node.mapIndexedNotNull { index, schema ->
+            schema.takeIf { it.isObject || it.isBoolean }?.let { readSchema(it, "$location/$index", version) }
+        }
+    }
 
     private fun readTypes(
         node: JsonNode,

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
@@ -1,0 +1,74 @@
+package com.cjbooms.fabrikt.parser
+
+import com.cjbooms.fabrikt.util.YamlObjectMapper
+import com.fasterxml.jackson.databind.JsonNode
+
+internal data class SourceOpenApiDocument(
+    val content: String,
+    val root: JsonNode,
+    val version: OpenApiVersion?,
+    val componentSchemas: Map<String, SourceSchema>,
+)
+
+internal object SourceOpenApiDocumentParser {
+    fun parse(input: String): SourceOpenApiDocument {
+        val root = YamlObjectMapper.instance.readTree(input)
+        val version = OpenApiVersion.parse(root["openapi"]?.asText())
+        return SourceOpenApiDocument(
+            content = input,
+            root = root,
+            version = version,
+            componentSchemas = readComponentSchemas(root, version),
+        )
+    }
+
+    private fun readComponentSchemas(
+        root: JsonNode,
+        version: OpenApiVersion?,
+    ): Map<String, SourceSchema> {
+        val schemas = root.path("components").path("schemas")
+        if (!schemas.isObject) return emptyMap()
+
+        return schemas.properties().associate { (name, node) ->
+            name to readSchema(node, "#/components/schemas/${name.toJsonPointerToken()}", version)
+        }
+    }
+
+    private fun readSchema(
+        node: JsonNode,
+        location: String,
+        version: OpenApiVersion?,
+    ): SourceSchema =
+        if (node.isBoolean) {
+            SourceBooleanSchema(location, node, node.booleanValue())
+        } else {
+            SourceObjectSchema(
+                location = location,
+                node = node,
+                types = readTypes(node, version),
+                reference = node["\$ref"]?.takeIf(JsonNode::isTextual)?.textValue(),
+            )
+        }
+
+    private fun readTypes(
+        node: JsonNode,
+        version: OpenApiVersion?,
+    ): Set<SourceSchemaType> {
+        val typeNode = node["type"]
+        val declaredTypes =
+            when {
+                typeNode?.isTextual == true -> sequenceOf(typeNode.textValue())
+                typeNode?.isArray == true -> typeNode.asSequence().filter(JsonNode::isTextual).map(JsonNode::textValue)
+                else -> emptySequence()
+            }.mapNotNull(SourceSchemaType::from)
+                .toCollection(linkedSetOf())
+
+        if (version?.major == 3 && version.minor == 0 && declaredTypes.isNotEmpty() && node["nullable"]?.asBoolean() == true) {
+            declaredTypes.add(SourceSchemaType.NULL)
+        }
+
+        return declaredTypes
+    }
+
+    private fun String.toJsonPointerToken(): String = replace("~", "~0").replace("/", "~1")
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
@@ -102,7 +102,7 @@ internal object SourceOpenApiDocumentParser {
                 typeNode?.isTextual == true -> sequenceOf(typeNode.textValue())
                 typeNode?.isArray == true -> typeNode.asSequence().filter(JsonNode::isTextual).map(JsonNode::textValue)
                 else -> emptySequence()
-            }.mapNotNull(SourceSchemaType::from)
+            }.map(SourceSchemaType::from)
                 .toCollection(linkedSetOf())
 
         if (version?.major == 3 && version.minor == 0 && declaredTypes.isNotEmpty() && node["nullable"]?.asBoolean() == true) {

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
@@ -1,0 +1,38 @@
+package com.cjbooms.fabrikt.parser
+
+import com.fasterxml.jackson.databind.JsonNode
+
+internal sealed interface SourceSchema {
+    val location: String
+    val node: JsonNode
+}
+
+internal data class SourceBooleanSchema(
+    override val location: String,
+    override val node: JsonNode,
+    val allowsAnyValue: Boolean,
+) : SourceSchema
+
+internal data class SourceObjectSchema(
+    override val location: String,
+    override val node: JsonNode,
+    val types: Set<SourceSchemaType>,
+    val reference: String?,
+) : SourceSchema
+
+internal enum class SourceSchemaType(
+    val value: String,
+) {
+    ARRAY("array"),
+    BOOLEAN("boolean"),
+    INTEGER("integer"),
+    NULL("null"),
+    NUMBER("number"),
+    OBJECT("object"),
+    STRING("string"),
+    ;
+
+    companion object {
+        fun from(value: String): SourceSchemaType? = entries.firstOrNull { it.value == value }
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
@@ -18,6 +18,13 @@ internal data class SourceObjectSchema(
     override val node: JsonNode,
     val types: Set<SourceSchemaType>,
     val reference: String?,
+    val properties: Map<String, SourceSchema>,
+    val items: SourceSchema?,
+    val allOf: List<SourceSchema>,
+    val anyOf: List<SourceSchema>,
+    val oneOf: List<SourceSchema>,
+    val not: SourceSchema?,
+    val additionalProperties: SourceSchema?,
 ) : SourceSchema
 
 internal enum class SourceSchemaType(

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
@@ -27,19 +27,34 @@ internal data class SourceObjectSchema(
     val additionalProperties: SourceSchema?,
 ) : SourceSchema
 
-internal enum class SourceSchemaType(
-    val value: String,
-) {
-    ARRAY("array"),
-    BOOLEAN("boolean"),
-    INTEGER("integer"),
-    NULL("null"),
-    NUMBER("number"),
-    OBJECT("object"),
-    STRING("string"),
-    ;
+internal sealed interface SourceSchemaType {
+    val value: String
+
+    enum class Recognised(
+        override val value: String,
+    ) : SourceSchemaType {
+        ARRAY("array"),
+        BOOLEAN("boolean"),
+        INTEGER("integer"),
+        NULL("null"),
+        NUMBER("number"),
+        OBJECT("object"),
+        STRING("string"),
+    }
+
+    data class Unrecognised(
+        override val value: String,
+    ) : SourceSchemaType
 
     companion object {
-        fun from(value: String): SourceSchemaType? = entries.firstOrNull { it.value == value }
+        val ARRAY: SourceSchemaType = Recognised.ARRAY
+        val BOOLEAN: SourceSchemaType = Recognised.BOOLEAN
+        val INTEGER: SourceSchemaType = Recognised.INTEGER
+        val NULL: SourceSchemaType = Recognised.NULL
+        val NUMBER: SourceSchemaType = Recognised.NUMBER
+        val OBJECT: SourceSchemaType = Recognised.OBJECT
+        val STRING: SourceSchemaType = Recognised.STRING
+
+        fun from(value: String): SourceSchemaType = Recognised.entries.firstOrNull { it.value == value } ?: Unrecognised(value)
     }
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParserTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParserTest.kt
@@ -1,6 +1,5 @@
 package com.cjbooms.fabrikt.parser
 
-import com.cjbooms.fabrikt.util.YamlUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -25,7 +24,7 @@ class OpenApiDocumentParserTest {
             """.trimIndent()
 
         val parsedDocument = OpenApiDocumentParser.parse(input)
-        val source = YamlUtils.objectMapper.readTree(parsedDocument.sourceContent)
+        val source = parsedDocument.source.root
 
         assertThat(source.at("/components/schemas/Name/type").map { it.textValue() })
             .containsExactly("string", "null")

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocumentParserTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocumentParserTest.kt
@@ -26,12 +26,13 @@ class SourceOpenApiDocumentParserTest {
     fun `preserves boolean schemas that cannot be represented by Kaizen`() {
         val document =
             SourceOpenApiDocumentParser.parse(
-                document(
-                    "3.1.2",
-                    """
+                createOpenApi3Document(
+                    version = "3.1.2",
+                    componentSchemas =
+                        """
                     AllowsAnything: true
                     AllowsNothing: false
-                    """,
+                        """,
                 ),
             )
 
@@ -52,15 +53,16 @@ class SourceOpenApiDocumentParserTest {
     @Test
     fun `preserves references siblings unknown keywords and escaped source locations`() {
         val input =
-            document(
-                "3.2.0",
-                """
+            createOpenApi3Document(
+                version = "3.2.0",
+                componentSchemas =
+                    """
                 Value~with/slash:
                   ${'$'}ref: '#/components/schemas/Target'
                   description: Retained reference sibling
                   futureKeyword:
                     nested: true
-                """,
+                    """,
             )
         val document =
             SourceOpenApiDocumentParser.parse(input)
@@ -78,9 +80,10 @@ class SourceOpenApiDocumentParserTest {
     fun `models nested schema structures recursively across OpenAPI versions`(version: String) {
         val document =
             SourceOpenApiDocumentParser.parse(
-                document(
-                    version,
-                    """
+                createOpenApi3Document(
+                    version = version,
+                    componentSchemas =
+                        """
                     Value:
                       type: object
                       properties:
@@ -100,7 +103,7 @@ class SourceOpenApiDocumentParserTest {
                         type: integer
                       additionalProperties:
                         type: boolean
-                    """,
+                        """,
                 ),
             )
         val value = document.componentSchemas["Value"] as SourceObjectSchema
@@ -128,36 +131,61 @@ class SourceOpenApiDocumentParserTest {
             .containsExactly(SourceSchemaType.BOOLEAN)
     }
 
+    @Test
+    fun `preserves unrecognised schema types`() {
+        val document =
+            SourceOpenApiDocumentParser.parse(
+                createOpenApi3Document(
+                    version = "3.1.2",
+                    componentSchemas =
+                        """
+                        Unknown:
+                          type: future
+                        Mixed:
+                          type: [string, future]
+                        """,
+                ),
+            )
+
+        assertThat((document.componentSchemas["Unknown"] as SourceObjectSchema).types)
+            .containsExactly(SourceSchemaType.Unrecognised("future"))
+        assertThat((document.componentSchemas["Mixed"] as SourceObjectSchema).types)
+            .containsExactly(SourceSchemaType.STRING, SourceSchemaType.Unrecognised("future"))
+    }
+
     @Suppress("unused")
     private fun nullableStringDocuments(): Stream<String> =
         Stream.of(
-            document(
-                "3.0.4",
-                """
+            createOpenApi3Document(
+                version = "3.0.4",
+                componentSchemas =
+                    """
                 Value:
                   type: string
                   nullable: true
-                """,
+                    """,
             ),
-            document(
-                "3.1.2",
-                """
+            createOpenApi3Document(
+                version = "3.1.2",
+                componentSchemas =
+                    """
                 Value:
                   type: [string, 'null']
-                """,
+                    """,
             ),
-            document(
-                "3.2.0",
-                """
+            createOpenApi3Document(
+                version = "3.2.0",
+                componentSchemas =
+                    """
                 Value:
                   type: [string, 'null']
-                """,
+                    """,
             ),
         )
 
-    private fun document(
+    private fun createOpenApi3Document(
         version: String,
-        schemas: String,
+        componentSchemas: String,
     ): String =
         """
         openapi: $version
@@ -167,6 +195,6 @@ class SourceOpenApiDocumentParserTest {
         paths: {}
         components:
           schemas:
-${schemas.trimIndent().prependIndent("            ")}
+${componentSchemas.trimIndent().prependIndent("            ")}
         """.trimIndent()
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocumentParserTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocumentParserTest.kt
@@ -1,0 +1,116 @@
+package com.cjbooms.fabrikt.parser
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.InstanceOfAssertFactories.type
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SourceOpenApiDocumentParserTest {
+    @ParameterizedTest
+    @MethodSource("nullableStringDocuments")
+    fun `normalizes equivalent nullable types across OpenAPI versions`(input: String) {
+        val document = SourceOpenApiDocumentParser.parse(input)
+
+        assertThat(document.componentSchemas["Value"])
+            .asInstanceOf(type(SourceObjectSchema::class.java))
+            .extracting(SourceObjectSchema::types)
+            .isEqualTo(linkedSetOf(SourceSchemaType.STRING, SourceSchemaType.NULL))
+    }
+
+    @Test
+    fun `preserves boolean schemas that cannot be represented by Kaizen`() {
+        val document =
+            SourceOpenApiDocumentParser.parse(
+                document(
+                    "3.1.2",
+                    """
+                    AllowsAnything: true
+                    AllowsNothing: false
+                    """,
+                ),
+            )
+
+        assertThat(document.componentSchemas["AllowsAnything"])
+            .isEqualTo(
+                SourceBooleanSchema(
+                    location = "#/components/schemas/AllowsAnything",
+                    node = document.root.at("/components/schemas/AllowsAnything"),
+                    allowsAnyValue = true,
+                ),
+            )
+        assertThat(document.componentSchemas["AllowsNothing"])
+            .asInstanceOf(type(SourceBooleanSchema::class.java))
+            .extracting(SourceBooleanSchema::allowsAnyValue)
+            .isEqualTo(false)
+    }
+
+    @Test
+    fun `preserves references siblings unknown keywords and escaped source locations`() {
+        val input =
+            document(
+                "3.2.0",
+                """
+                Value~with/slash:
+                  ${'$'}ref: '#/components/schemas/Target'
+                  description: Retained reference sibling
+                  futureKeyword:
+                    nested: true
+                """,
+            )
+        val document =
+            SourceOpenApiDocumentParser.parse(input)
+        val schema = document.componentSchemas["Value~with/slash"] as SourceObjectSchema
+
+        assertThat(document.content).isEqualTo(input)
+        assertThat(schema.location).isEqualTo("#/components/schemas/Value~0with~1slash")
+        assertThat(schema.reference).isEqualTo("#/components/schemas/Target")
+        assertThat(schema.node["description"].textValue()).isEqualTo("Retained reference sibling")
+        assertThat(schema.node.at("/futureKeyword/nested").booleanValue()).isTrue()
+    }
+
+    @Suppress("unused")
+    private fun nullableStringDocuments(): Stream<String> =
+        Stream.of(
+            document(
+                "3.0.4",
+                """
+                Value:
+                  type: string
+                  nullable: true
+                """,
+            ),
+            document(
+                "3.1.2",
+                """
+                Value:
+                  type: [string, 'null']
+                """,
+            ),
+            document(
+                "3.2.0",
+                """
+                Value:
+                  type: [string, 'null']
+                """,
+            ),
+        )
+
+    private fun document(
+        version: String,
+        schemas: String,
+    ): String =
+        """
+        openapi: $version
+        info:
+          title: Test
+          version: "1.0"
+        paths: {}
+        components:
+          schemas:
+${schemas.trimIndent().prependIndent("            ")}
+        """.trimIndent()
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocumentParserTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocumentParserTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.util.stream.Stream
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -70,6 +71,61 @@ class SourceOpenApiDocumentParserTest {
         assertThat(schema.reference).isEqualTo("#/components/schemas/Target")
         assertThat(schema.node["description"].textValue()).isEqualTo("Retained reference sibling")
         assertThat(schema.node.at("/futureKeyword/nested").booleanValue()).isTrue()
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["3.0.4", "3.1.2", "3.2.0"])
+    fun `models nested schema structures recursively across OpenAPI versions`(version: String) {
+        val document =
+            SourceOpenApiDocumentParser.parse(
+                document(
+                    version,
+                    """
+                    Value:
+                      type: object
+                      properties:
+                        child~with/slash:
+                          type: array
+                          items:
+                            oneOf:
+                              - type: string
+                              - type: integer
+                      allOf:
+                        - type: object
+                      anyOf:
+                        - type: string
+                      oneOf:
+                        - type: number
+                      not:
+                        type: integer
+                      additionalProperties:
+                        type: boolean
+                    """,
+                ),
+            )
+        val value = document.componentSchemas["Value"] as SourceObjectSchema
+        val property = value.properties["child~with/slash"] as SourceObjectSchema
+        val items = property.items as SourceObjectSchema
+
+        assertThat(property.location).isEqualTo("#/components/schemas/Value/properties/child~0with~1slash")
+        assertThat(property.types).containsExactly(SourceSchemaType.ARRAY)
+        assertThat(items.location).isEqualTo("#/components/schemas/Value/properties/child~0with~1slash/items")
+        assertThat(items.oneOf.map(SourceSchema::location))
+            .containsExactly(
+                "#/components/schemas/Value/properties/child~0with~1slash/items/oneOf/0",
+                "#/components/schemas/Value/properties/child~0with~1slash/items/oneOf/1",
+            )
+        assertThat((items.oneOf[0] as SourceObjectSchema).types).containsExactly(SourceSchemaType.STRING)
+        assertThat((items.oneOf[1] as SourceObjectSchema).types).containsExactly(SourceSchemaType.INTEGER)
+        assertThat(value.allOf.single().location).isEqualTo("#/components/schemas/Value/allOf/0")
+        assertThat(value.anyOf.single().location).isEqualTo("#/components/schemas/Value/anyOf/0")
+        assertThat((value.anyOf.single() as SourceObjectSchema).types).containsExactly(SourceSchemaType.STRING)
+        assertThat(value.oneOf.single().location).isEqualTo("#/components/schemas/Value/oneOf/0")
+        assertThat(value.not!!.location).isEqualTo("#/components/schemas/Value/not")
+        assertThat((value.not as SourceObjectSchema).types).containsExactly(SourceSchemaType.INTEGER)
+        assertThat(value.additionalProperties!!.location).isEqualTo("#/components/schemas/Value/additionalProperties")
+        assertThat((value.additionalProperties as SourceObjectSchema).types)
+            .containsExactly(SourceSchemaType.BOOLEAN)
     }
 
     @Suppress("unused")


### PR DESCRIPTION
## Summary

Introduces a lossless, Fabrikt-owned source representation alongside the existing Kaizen model.

`SourceOpenApiDocument` retains the original input and unmodified parsed document. Kaizen compatibility transformations are now applied to a deep copy, preventing information from the original OpenAPI document from being lost before future processing can use it.

The initial `SourceSchema` model represents:

- object and boolean schemas;
- single and multiple schema types;
- equivalent nullable semantics across OpenAPI 3.0, 3.1, and 3.2;
- `$ref` values and `$ref` siblings;
- unknown and future keywords through the original schema node;
- recursively nested `properties`, `items`, `allOf`, `anyOf`, `oneOf`, `not`, and `additionalProperties`;
- exact JSON Pointer locations, including escaped property and component names.

## Motivation

Fabrikt currently applies compatibility transformations before passing a document to Kaizen. Although this allows the existing generators to keep working, OpenAPI 3.1 and 3.2 information may be simplified or discarded in the process.

This change establishes a lossless parsing boundary and the first version of a parser-independent schema model. It allows future OpenAPI 3.1 and 3.2 work to use the original schema semantics while keeping the existing Kaizen-based generation pipeline unchanged.

This is intended as an incremental architectural step related to #656, not as a claim of complete OpenAPI 3.1 or 3.2 generation support.

## Compatibility

Existing generators continue to use the Kaizen model. This PR does not change generated code or existing golden files.

## Testing

Added contract tests covering:

- source preservation before Kaizen compatibility transformations;
- OpenAPI version detection for 3.0, 3.1, and 3.2;
- equivalent nullable representations across these versions;
- boolean schemas;
- `$ref` siblings and unknown keywords;
- recursively nested schema structures;
- JSON Pointer escaping.

The full build passes successfully, including all end-to-end projects:

```text
BUILD SUCCESSFUL
126 actionable tasks: 126 executed
```

Refs #656