### PR TITLE
Update Jackson 2 and Jackson 3 dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,8 @@ kotlinx-datetime-legacy = "0.6.2"
 kotlinx-serialization = "1.9.0"
 
 # Jackson / Serialization
-jackson = "2.20.1"
-jackson3 = "3.2.0"
+jackson = "2.21.6"
+jackson3 = "3.2.2"
 jackson-databind-nullable = "0.2.10"
 
 # OpenAPI


### PR DESCRIPTION
## Summary

Updates the supported Jackson dependency lines to their latest patch releases:

- Jackson 2 from `2.20.1` to `2.21.6`
- Jackson 3 from `3.2.0` to `3.2.2`

These releases include upstream security and stability fixes. This is a dependency-only maintenance update: it does not change Fabrikt's code, public API, CLI behaviour or generated output.

## Validation

- The existing build and test suite pass successfully.
- Both Jackson 2 and Jackson 3 generation scenarios remain covered.