### PR TITLE
Document the official Fabrikt Maven plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,11 @@ fabrikt {
 
 ### Maven
 
-The [exec-maven-plugin](https://www.mojohaus.org/exec-maven-plugin/examples/example-exec-using-plugin-dependencies.html) is capable of downloading the Fabrikt library from Maven Central and executing its main method with defined arguments.
+The [official Fabrikt Maven plugin](https://github.com/fabrikt-io/fabrikt-maven-plugin) integrates Fabrikt code generation into Maven builds.
+Plugin releases use the same version as the corresponding Fabrikt release and support shared configuration, multiple OpenAPI specifications through named executions, generated source registration, and both lifecycle-bound and explicit generation.
+Refer to the plugin's [usage documentation](https://github.com/fabrikt-io/fabrikt-maven-plugin#usage) for the current configuration syntax and examples.
+
+Alternatively, the [exec-maven-plugin](https://www.mojohaus.org/exec-maven-plugin/examples/example-exec-using-plugin-dependencies.html) can download the Fabrikt library from Maven Central and execute its main method with defined arguments.
 
 ### Docker
 


### PR DESCRIPTION
## Summary

Updates the Maven usage section to reference the official standalone [[Fabrikt Maven plugin](https://github.com/fabrikt-io/fabrikt-maven-plugin)](https://github.com/fabrikt-io/fabrikt-maven-plugin).

The documentation now:

- describes the lockstep versioning between Fabrikt and the Maven plugin;
- highlights shared configuration, multiple API specifications and Maven lifecycle integration;
- links to the plugin repository for current configuration and examples;
- retains `exec-maven-plugin` as an alternative integration method.

## Merge dependency

This PR should only be merged after fabrikt-io/fabrikt-maven-plugin#1 has been merged. Until then, the linked plugin documentation is not yet available on the plugin repository’s default branch.

## Testing

- `./gradlew build`

Related to #664.