### PR TITLE
Collect and index OpenAPI source schema entry points

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
@@ -54,15 +54,7 @@ internal object SourceOpenApiDocumentParser {
 
     private fun SourceSchema.visitRecursively(visitor: (SourceSchema) -> Unit) {
         visitor(this)
-        if (this !is SourceObjectSchema) return
-
-        properties.values.forEach { it.visitRecursively(visitor) }
-        items?.visitRecursively(visitor)
-        allOf.forEach { it.visitRecursively(visitor) }
-        anyOf.forEach { it.visitRecursively(visitor) }
-        oneOf.forEach { it.visitRecursively(visitor) }
-        not?.visitRecursively(visitor)
-        additionalProperties?.visitRecursively(visitor)
+        childSchemas().forEach { it.visitRecursively(visitor) }
     }
 
     private fun readSchema(
@@ -78,8 +70,27 @@ internal object SourceOpenApiDocumentParser {
                 node = node,
                 types = readTypes(node, version),
                 reference = node["\$ref"]?.takeIf(JsonNode::isTextual)?.textValue(),
+                definitions = readNamedSchemas(node["\$defs"], "$location/\$defs", version),
                 properties = readNamedSchemas(node["properties"], "$location/properties", version),
+                patternProperties =
+                    readNamedSchemas(
+                        node["patternProperties"],
+                        "$location/patternProperties",
+                        version,
+                    ),
+                dependentSchemas =
+                    readNamedSchemas(
+                        node["dependentSchemas"],
+                        "$location/dependentSchemas",
+                        version,
+                    ),
+                prefixItems = readSchemaList(node["prefixItems"], "$location/prefixItems", version),
                 items = readOptionalSchema(node["items"], "$location/items", version),
+                contains = readOptionalSchema(node["contains"], "$location/contains", version),
+                propertyNames = readOptionalSchema(node["propertyNames"], "$location/propertyNames", version),
+                ifSchema = readOptionalSchema(node["if"], "$location/if", version),
+                thenSchema = readOptionalSchema(node["then"], "$location/then", version),
+                elseSchema = readOptionalSchema(node["else"], "$location/else", version),
                 allOf = readSchemaList(node["allOf"], "$location/allOf", version),
                 anyOf = readSchemaList(node["anyOf"], "$location/anyOf", version),
                 oneOf = readSchemaList(node["oneOf"], "$location/oneOf", version),
@@ -90,6 +101,19 @@ internal object SourceOpenApiDocumentParser {
                         "$location/additionalProperties",
                         version,
                     ),
+                unevaluatedItems =
+                    readOptionalSchema(
+                        node["unevaluatedItems"],
+                        "$location/unevaluatedItems",
+                        version,
+                    ),
+                unevaluatedProperties =
+                    readOptionalSchema(
+                        node["unevaluatedProperties"],
+                        "$location/unevaluatedProperties",
+                        version,
+                    ),
+                contentSchema = readOptionalSchema(node["contentSchema"], "$location/contentSchema", version),
             )
         }
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
@@ -8,30 +8,61 @@ internal data class SourceOpenApiDocument(
     val root: JsonNode,
     val version: OpenApiVersion?,
     val componentSchemas: Map<String, SourceSchema>,
+    val schemaEntryPoints: Map<String, SourceSchema>,
+    val schemasByLocation: Map<String, SourceSchema>,
 )
 
 internal object SourceOpenApiDocumentParser {
     fun parse(input: String): SourceOpenApiDocument {
         val root = YamlObjectMapper.instance.readTree(input)
         val version = OpenApiVersion.parse(root["openapi"]?.asText())
+        val schemaEntryPoints =
+            SourceSchemaEntryPointCollector
+                .collect(root, version)
+                .mapValues { (location, node) -> readSchema(node, location, version) }
         return SourceOpenApiDocument(
             content = input,
             root = root,
             version = version,
-            componentSchemas = readComponentSchemas(root, version),
+            componentSchemas = readComponentSchemas(root, schemaEntryPoints),
+            schemaEntryPoints = schemaEntryPoints,
+            schemasByLocation = indexSchemas(schemaEntryPoints.values),
         )
     }
 
     private fun readComponentSchemas(
         root: JsonNode,
-        version: OpenApiVersion?,
+        schemaEntryPoints: Map<String, SourceSchema>,
     ): Map<String, SourceSchema> {
         val schemas = root.path("components").path("schemas")
         if (!schemas.isObject) return emptyMap()
 
-        return schemas.properties().associate { (name, node) ->
-            name to readSchema(node, "#/components/schemas/${name.toJsonPointerToken()}", version)
+        return schemas.properties().associate { (name, _) ->
+            name to schemaEntryPoints.getValue("#/components/schemas/${name.toJsonPointerToken()}")
         }
+    }
+
+    private fun indexSchemas(entryPoints: Collection<SourceSchema>): Map<String, SourceSchema> =
+        buildMap {
+            entryPoints.forEach { entryPoint ->
+                entryPoint.visitRecursively { schema ->
+                    check(schema.location !in this) { "Duplicate source schema location: ${schema.location}" }
+                    put(schema.location, schema)
+                }
+            }
+        }
+
+    private fun SourceSchema.visitRecursively(visitor: (SourceSchema) -> Unit) {
+        visitor(this)
+        if (this !is SourceObjectSchema) return
+
+        properties.values.forEach { it.visitRecursively(visitor) }
+        items?.visitRecursively(visitor)
+        allOf.forEach { it.visitRecursively(visitor) }
+        anyOf.forEach { it.visitRecursively(visitor) }
+        oneOf.forEach { it.visitRecursively(visitor) }
+        not?.visitRecursively(visitor)
+        additionalProperties?.visitRecursively(visitor)
     }
 
     private fun readSchema(

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
@@ -18,14 +18,53 @@ internal data class SourceObjectSchema(
     override val node: JsonNode,
     val types: Set<SourceSchemaType>,
     val reference: String?,
+    val definitions: Map<String, SourceSchema>,
     val properties: Map<String, SourceSchema>,
+    val patternProperties: Map<String, SourceSchema>,
+    val dependentSchemas: Map<String, SourceSchema>,
+    val prefixItems: List<SourceSchema>,
     val items: SourceSchema?,
+    val contains: SourceSchema?,
+    val propertyNames: SourceSchema?,
+    val ifSchema: SourceSchema?,
+    val thenSchema: SourceSchema?,
+    val elseSchema: SourceSchema?,
     val allOf: List<SourceSchema>,
     val anyOf: List<SourceSchema>,
     val oneOf: List<SourceSchema>,
     val not: SourceSchema?,
     val additionalProperties: SourceSchema?,
+    val unevaluatedItems: SourceSchema?,
+    val unevaluatedProperties: SourceSchema?,
+    val contentSchema: SourceSchema?,
 ) : SourceSchema
+
+internal fun SourceSchema.childSchemas(): Sequence<SourceSchema> =
+    when (this) {
+        is SourceBooleanSchema -> emptySequence()
+        is SourceObjectSchema ->
+            sequence {
+                yieldAll(definitions.values)
+                yieldAll(properties.values)
+                yieldAll(patternProperties.values)
+                yieldAll(dependentSchemas.values)
+                yieldAll(prefixItems)
+                items?.let { yield(it) }
+                contains?.let { yield(it) }
+                propertyNames?.let { yield(it) }
+                ifSchema?.let { yield(it) }
+                thenSchema?.let { yield(it) }
+                elseSchema?.let { yield(it) }
+                yieldAll(allOf)
+                yieldAll(anyOf)
+                yieldAll(oneOf)
+                not?.let { yield(it) }
+                additionalProperties?.let { yield(it) }
+                unevaluatedItems?.let { yield(it) }
+                unevaluatedProperties?.let { yield(it) }
+                contentSchema?.let { yield(it) }
+            }
+    }
 
 internal sealed interface SourceSchemaType {
     val value: String

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaEntryPointCollector.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaEntryPointCollector.kt
@@ -1,0 +1,232 @@
+package com.cjbooms.fabrikt.parser
+
+import com.fasterxml.jackson.databind.JsonNode
+
+internal object SourceSchemaEntryPointCollector {
+    fun collect(
+        root: JsonNode,
+        version: OpenApiVersion?,
+    ): Map<String, JsonNode> = Collector(version).collect(root)
+
+    private class Collector(
+        version: OpenApiVersion?,
+    ) {
+        private val entryPoints = linkedMapOf<String, JsonNode>()
+        private val supportsOpenApi31 = version.isAtLeast(3, 1)
+        private val supportsOpenApi32 = version.isAtLeast(3, 2)
+
+        fun collect(root: JsonNode): Map<String, JsonNode> {
+            collectComponents(root["components"], "#/components")
+            collectPathItemMap(root["paths"], "#/paths", pathsOnly = true)
+            if (supportsOpenApi31) collectPathItemMap(root["webhooks"], "#/webhooks")
+            return entryPoints
+        }
+
+        private fun collectComponents(
+            components: JsonNode?,
+            location: String,
+        ) {
+            collectSchemaMap(components?.get("schemas"), "$location/schemas")
+            collectObjectMap(components?.get("parameters"), "$location/parameters", ::collectParameter)
+            collectObjectMap(components?.get("headers"), "$location/headers", ::collectHeader)
+            collectObjectMap(components?.get("requestBodies"), "$location/requestBodies", ::collectRequestBody)
+            collectObjectMap(components?.get("responses"), "$location/responses", ::collectResponse)
+            collectObjectMap(components?.get("callbacks"), "$location/callbacks", ::collectCallback)
+            if (supportsOpenApi31) {
+                collectObjectMap(components?.get("pathItems"), "$location/pathItems", ::collectPathItem)
+            }
+            if (supportsOpenApi32) {
+                collectObjectMap(components?.get("mediaTypes"), "$location/mediaTypes", ::collectMediaType)
+            }
+        }
+
+        private fun collectPathItemMap(
+            pathItems: JsonNode?,
+            location: String,
+            pathsOnly: Boolean = false,
+            skipSpecificationExtensions: Boolean = false,
+        ) {
+            if (pathItems?.isObject != true) return
+
+            pathItems
+                .properties()
+                .filter { (name, _) -> !pathsOnly || name.startsWith("/") }
+                .filterNot { (name, _) -> skipSpecificationExtensions && name.isSpecificationExtension() }
+                .forEach { (name, pathItem) -> collectPathItem(pathItem, "$location/${name.toJsonPointerToken()}") }
+        }
+
+        private fun collectPathItem(
+            pathItem: JsonNode?,
+            location: String,
+        ) {
+            if (pathItem?.isObject != true) return
+            collectParameters(pathItem["parameters"], "$location/parameters")
+            operationNames.forEach { operationName ->
+                collectOperation(pathItem[operationName], "$location/$operationName")
+            }
+            if (supportsOpenApi32) {
+                collectObjectMap(
+                    pathItem["additionalOperations"],
+                    "$location/additionalOperations",
+                    ::collectOperation,
+                )
+            }
+        }
+
+        private fun collectOperation(
+            operation: JsonNode?,
+            location: String,
+        ) {
+            if (operation?.isObject != true) return
+
+            collectParameters(operation["parameters"], "$location/parameters")
+            collectRequestBody(operation["requestBody"], "$location/requestBody")
+            collectResponses(operation["responses"], "$location/responses")
+            collectObjectMap(operation["callbacks"], "$location/callbacks", ::collectCallback)
+        }
+
+        private fun collectParameters(
+            parameters: JsonNode?,
+            location: String,
+        ) {
+            if (parameters?.isArray != true) return
+            parameters.forEachIndexed { index, parameter -> collectParameter(parameter, "$location/$index") }
+        }
+
+        private fun collectParameter(
+            parameter: JsonNode?,
+            location: String,
+        ) {
+            if (!parameter.isInlineObject()) return
+            collectSchema(parameter?.get("schema"), "$location/schema")
+            collectContent(parameter?.get("content"), "$location/content")
+        }
+
+        private fun collectHeader(
+            header: JsonNode?,
+            location: String,
+        ) {
+            if (!header.isInlineObject()) return
+            collectSchema(header?.get("schema"), "$location/schema")
+            collectContent(header?.get("content"), "$location/content")
+        }
+
+        private fun collectRequestBody(
+            requestBody: JsonNode?,
+            location: String,
+        ) {
+            if (!requestBody.isInlineObject()) return
+            collectContent(requestBody?.get("content"), "$location/content")
+        }
+
+        private fun collectResponses(
+            responses: JsonNode?,
+            location: String,
+        ) = collectObjectMap(responses, location, ::collectResponse, skipSpecificationExtensions = true)
+
+        private fun collectResponse(
+            response: JsonNode?,
+            location: String,
+        ) {
+            if (!response.isInlineObject()) return
+            collectObjectMap(response?.get("headers"), "$location/headers", ::collectHeader)
+            collectContent(response?.get("content"), "$location/content")
+        }
+
+        private fun collectCallback(
+            callback: JsonNode?,
+            location: String,
+        ) {
+            if (!callback.isInlineObject()) return
+            collectPathItemMap(callback, location, skipSpecificationExtensions = true)
+        }
+
+        private fun collectContent(
+            content: JsonNode?,
+            location: String,
+        ) = collectObjectMap(content, location, ::collectMediaType)
+
+        private fun collectMediaType(
+            mediaType: JsonNode?,
+            location: String,
+        ) {
+            if (!mediaType.isInlineObject()) return
+            collectSchema(mediaType?.get("schema"), "$location/schema")
+            if (supportsOpenApi32) collectSchema(mediaType?.get("itemSchema"), "$location/itemSchema")
+            collectObjectMap(mediaType?.get("encoding"), "$location/encoding", ::collectEncoding)
+            if (supportsOpenApi32) {
+                collectEncodingArray(mediaType?.get("prefixEncoding"), "$location/prefixEncoding")
+                collectEncoding(mediaType?.get("itemEncoding"), "$location/itemEncoding")
+            }
+        }
+
+        private fun collectEncoding(
+            encoding: JsonNode?,
+            location: String,
+        ) {
+            if (encoding?.isObject != true) return
+            collectObjectMap(encoding["headers"], "$location/headers", ::collectHeader)
+            if (supportsOpenApi32) {
+                collectObjectMap(encoding["encoding"], "$location/encoding", ::collectEncoding)
+                collectEncodingArray(encoding["prefixEncoding"], "$location/prefixEncoding")
+                collectEncoding(encoding["itemEncoding"], "$location/itemEncoding")
+            }
+        }
+
+        private fun collectEncodingArray(
+            encodings: JsonNode?,
+            location: String,
+        ) {
+            if (encodings?.isArray != true) return
+            encodings.forEachIndexed { index, encoding -> collectEncoding(encoding, "$location/$index") }
+        }
+
+        private fun collectSchemaMap(
+            schemas: JsonNode?,
+            location: String,
+        ) {
+            if (schemas?.isObject != true) return
+            schemas.properties().forEach { (name, schema) ->
+                collectSchema(schema, "$location/${name.toJsonPointerToken()}")
+            }
+        }
+
+        private fun collectSchema(
+            schema: JsonNode?,
+            location: String,
+        ) {
+            if (schema?.isObject == true || schema?.isBoolean == true) entryPoints[location] = schema
+        }
+
+        private fun collectObjectMap(
+            objects: JsonNode?,
+            location: String,
+            collector: (JsonNode?, String) -> Unit,
+            skipSpecificationExtensions: Boolean = false,
+        ) {
+            if (objects?.isObject != true) return
+            objects
+                .properties()
+                .filterNot { (name, _) -> skipSpecificationExtensions && name.isSpecificationExtension() }
+                .forEach { (name, value) -> collector(value, "$location/${name.toJsonPointerToken()}") }
+        }
+
+        private fun JsonNode?.isInlineObject(): Boolean = this?.isObject == true && this["\$ref"]?.isTextual != true
+
+        private fun OpenApiVersion?.isAtLeast(
+            major: Int,
+            minor: Int,
+        ): Boolean = this != null && (this.major > major || this.major == major && this.minor >= minor)
+
+        private fun String.isSpecificationExtension(): Boolean = startsWith("x-", ignoreCase = true)
+
+        private fun String.toJsonPointerToken(): String = replace("~", "~0").replace("/", "~1")
+
+        private val operationNames: List<String>
+            get() = if (supportsOpenApi32) OPERATION_NAMES + "query" else OPERATION_NAMES
+
+        private companion object {
+            val OPERATION_NAMES = listOf("get", "put", "post", "delete", "options", "head", "patch", "trace")
+        }
+    }
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaChildrenTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaChildrenTest.kt
@@ -1,0 +1,111 @@
+package com.cjbooms.fabrikt.parser
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class SourceSchemaChildrenTest {
+    @ParameterizedTest
+    @ValueSource(strings = ["3.1.2", "3.2.0"])
+    fun `models and indexes JSON Schema 2020-12 child schemas`(version: String) {
+        val document =
+            SourceOpenApiDocumentParser.parse(
+                """
+                openapi: $version
+                info:
+                  title: Test
+                  version: "1.0"
+                paths: {}
+                components:
+                  schemas:
+                    Root:
+                      type: object
+                      ${'$'}defs:
+                        Named/with~escape:
+                          type: object
+                          properties:
+                            nested:
+                              type: string
+                      properties:
+                        direct:
+                          type: string
+                      patternProperties:
+                        pattern:
+                          type: integer
+                      dependentSchemas:
+                        feature/with~escape:
+                          type: object
+                      prefixItems:
+                        - type: string
+                        - false
+                      items:
+                        type: number
+                      contains: true
+                      propertyNames:
+                        type: string
+                      if:
+                        type: object
+                      then:
+                        type: string
+                      else:
+                        type: integer
+                      allOf:
+                        - type: object
+                      anyOf:
+                        - type: string
+                      oneOf:
+                        - type: boolean
+                      not:
+                        type: 'null'
+                      additionalProperties:
+                        type: string
+                      unevaluatedItems:
+                        type: number
+                      unevaluatedProperties: false
+                      contentSchema:
+                        type: object
+                """.trimIndent(),
+            )
+        val root = document.componentSchemas.getValue("Root") as SourceObjectSchema
+        val rootLocation = "#/components/schemas/Root"
+
+        assertThat(root.definitions).containsOnlyKeys("Named/with~escape")
+        assertThat(root.properties).containsOnlyKeys("direct")
+        assertThat(root.patternProperties).containsOnlyKeys("pattern")
+        assertThat(root.dependentSchemas).containsOnlyKeys("feature/with~escape")
+        assertThat(root.prefixItems).hasSize(2)
+        assertThat((root.prefixItems[1] as SourceBooleanSchema).allowsAnyValue).isFalse()
+        assertThat((root.contains as SourceBooleanSchema).allowsAnyValue).isTrue()
+        assertThat((root.unevaluatedProperties as SourceBooleanSchema).allowsAnyValue).isFalse()
+
+        assertThat(document.schemasByLocation.keys)
+            .containsExactlyInAnyOrder(
+                rootLocation,
+                "$rootLocation/${'$'}defs/Named~1with~0escape",
+                "$rootLocation/${'$'}defs/Named~1with~0escape/properties/nested",
+                "$rootLocation/properties/direct",
+                "$rootLocation/patternProperties/pattern",
+                "$rootLocation/dependentSchemas/feature~1with~0escape",
+                "$rootLocation/prefixItems/0",
+                "$rootLocation/prefixItems/1",
+                "$rootLocation/items",
+                "$rootLocation/contains",
+                "$rootLocation/propertyNames",
+                "$rootLocation/if",
+                "$rootLocation/then",
+                "$rootLocation/else",
+                "$rootLocation/allOf/0",
+                "$rootLocation/anyOf/0",
+                "$rootLocation/oneOf/0",
+                "$rootLocation/not",
+                "$rootLocation/additionalProperties",
+                "$rootLocation/unevaluatedItems",
+                "$rootLocation/unevaluatedProperties",
+                "$rootLocation/contentSchema",
+            )
+
+        root.childSchemas().forEach { child ->
+            assertThat(document.schemasByLocation[child.location]).isSameAs(child)
+        }
+    }
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaEntryPointCollectorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaEntryPointCollectorTest.kt
@@ -1,0 +1,269 @@
+package com.cjbooms.fabrikt.parser
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class SourceSchemaEntryPointCollectorTest {
+    @ParameterizedTest
+    @ValueSource(strings = ["3.0.4", "3.1.2", "3.2.0"])
+    fun `collects shared schema entry points across OpenAPI versions`(version: String) {
+        val document =
+            SourceOpenApiDocumentParser.parse(
+                """
+                openapi: $version
+                info:
+                  title: Test
+                  version: "1.0"
+                paths:
+                  /pets:
+                    parameters:
+                      - name: pathFilter
+                        in: query
+                        schema:
+                          type: string
+                    post:
+                      parameters:
+                        - name: operationFilter
+                          in: query
+                          content:
+                            application/json:
+                              schema:
+                                type: string
+                      requestBody:
+                        content:
+                          application/json:
+                            schema:
+                              type: object
+                              properties:
+                                names/with~escape:
+                                  type: array
+                                  items:
+                                    oneOf:
+                                      - type: string
+                                      - type: boolean
+                            encoding:
+                              value:
+                                headers:
+                                  X-Encoding:
+                                    schema:
+                                      type: string
+                      responses:
+                        '200':
+                          description: Success
+                          headers:
+                            X-Response:
+                              schema:
+                                type: integer
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                      callbacks:
+                        changed:
+                          '{${'$'}request.body#/callbackUrl}':
+                            post:
+                              requestBody:
+                                content:
+                                  application/json:
+                                    schema:
+                                      type: object
+                              responses:
+                                '204':
+                                  description: Accepted
+                components:
+                  schemas:
+                    Pet:
+                      type: object
+                  parameters:
+                    Limit:
+                      name: limit
+                      in: query
+                      schema:
+                        type: integer
+                  headers:
+                    RequestId:
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                  requestBodies:
+                    PetBody:
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                  responses:
+                    PetResponse:
+                      description: Pet response
+                      headers:
+                        X-Component:
+                          schema:
+                            type: string
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                  callbacks:
+                    ComponentCallback:
+                      '{${'$'}request.body#/callbackUrl}':
+                        post:
+                          requestBody:
+                            content:
+                              application/json:
+                                schema:
+                                  type: object
+                          responses:
+                            '204':
+                              description: Accepted
+                """.trimIndent(),
+            )
+
+        assertThat(document.schemaEntryPoints.keys)
+            .containsExactlyInAnyOrder(
+                "#/components/schemas/Pet",
+                "#/components/parameters/Limit/schema",
+                "#/components/headers/RequestId/content/text~1plain/schema",
+                "#/components/requestBodies/PetBody/content/application~1json/schema",
+                "#/components/responses/PetResponse/headers/X-Component/schema",
+                "#/components/responses/PetResponse/content/application~1json/schema",
+                "#/components/callbacks/ComponentCallback/{${'$'}request.body#~1callbackUrl}/post/requestBody/content/application~1json/schema",
+                "#/paths/~1pets/parameters/0/schema",
+                "#/paths/~1pets/post/parameters/0/content/application~1json/schema",
+                "#/paths/~1pets/post/requestBody/content/application~1json/schema",
+                "#/paths/~1pets/post/requestBody/content/application~1json/encoding/value/headers/X-Encoding/schema",
+                "#/paths/~1pets/post/responses/200/headers/X-Response/schema",
+                "#/paths/~1pets/post/responses/200/content/application~1json/schema",
+                "#/paths/~1pets/post/callbacks/changed/{${'$'}request.body#~1callbackUrl}/post/requestBody/content/application~1json/schema",
+            )
+        assertThat(document.componentSchemas["Pet"])
+            .isSameAs(document.schemaEntryPoints["#/components/schemas/Pet"])
+
+        val requestSchemaLocation = "#/paths/~1pets/post/requestBody/content/application~1json/schema"
+        val propertyLocation = "$requestSchemaLocation/properties/names~1with~0escape"
+        val itemsLocation = "$propertyLocation/items"
+        val requestSchema = document.schemaEntryPoints.getValue(requestSchemaLocation) as SourceObjectSchema
+        val propertySchema = requestSchema.properties.getValue("names/with~escape") as SourceObjectSchema
+        val itemsSchema = propertySchema.items as SourceObjectSchema
+
+        assertThat(document.schemasByLocation).containsAllEntriesOf(document.schemaEntryPoints)
+        assertThat(document.schemasByLocation[propertyLocation]).isSameAs(propertySchema)
+        assertThat(document.schemasByLocation[itemsLocation]).isSameAs(itemsSchema)
+        assertThat(document.schemasByLocation["$itemsLocation/oneOf/0"]).isSameAs(itemsSchema.oneOf[0])
+        assertThat(document.schemasByLocation["$itemsLocation/oneOf/1"]).isSameAs(itemsSchema.oneOf[1])
+        assertThat(document.schemasByLocation).hasSize(document.schemaEntryPoints.size + 4)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["3.1.2", "3.2.0"])
+    fun `collects webhooks and reusable path items in OpenAPI 3_1 and later`(version: String) {
+        val document =
+            SourceOpenApiDocumentParser.parse(
+                """
+                openapi: $version
+                info:
+                  title: Test
+                  version: "1.0"
+                paths: {}
+                webhooks:
+                  x-newPet:
+                    post:
+                      requestBody:
+                        content:
+                          application/json:
+                            schema:
+                              type: object
+                      responses:
+                        '204':
+                          description: Accepted
+                components:
+                  pathItems:
+                    Reusable:
+                      get:
+                        responses:
+                          '200':
+                            description: Success
+                            content:
+                              application/json:
+                                schema:
+                                  type: object
+                """.trimIndent(),
+            )
+
+        assertThat(document.schemaEntryPoints.keys)
+            .containsExactlyInAnyOrder(
+                "#/webhooks/x-newPet/post/requestBody/content/application~1json/schema",
+                "#/components/pathItems/Reusable/get/responses/200/content/application~1json/schema",
+            )
+    }
+
+    @Test
+    fun `collects OpenAPI 3_2 media type and operation schema entry points`() {
+        val document =
+            SourceOpenApiDocumentParser.parse(
+                """
+                openapi: 3.2.0
+                info:
+                  title: Test
+                  version: "1.0"
+                paths:
+                  /events:
+                    query:
+                      responses:
+                        '200':
+                          description: Events
+                          content:
+                            application/json-seq:
+                              itemSchema:
+                                type: object
+                    additionalOperations:
+                      PURGE:
+                        requestBody:
+                          content:
+                            multipart/mixed:
+                              schema:
+                                type: array
+                              prefixEncoding:
+                                - headers:
+                                    X-Prefix:
+                                      schema:
+                                        type: string
+                              itemEncoding:
+                                headers:
+                                  X-Item:
+                                    schema:
+                                      type: integer
+                              encoding:
+                                envelope:
+                                  encoding:
+                                    nested:
+                                      headers:
+                                        X-Nested:
+                                          schema:
+                                            type: boolean
+                        responses:
+                          '204':
+                            description: Purged
+                components:
+                  mediaTypes:
+                    EventStream:
+                      schema:
+                        type: array
+                      itemSchema:
+                        type: object
+                """.trimIndent(),
+            )
+
+        assertThat(document.schemaEntryPoints.keys)
+            .containsExactlyInAnyOrder(
+                "#/components/mediaTypes/EventStream/schema",
+                "#/components/mediaTypes/EventStream/itemSchema",
+                "#/paths/~1events/query/responses/200/content/application~1json-seq/itemSchema",
+                "#/paths/~1events/additionalOperations/PURGE/requestBody/content/multipart~1mixed/schema",
+                "#/paths/~1events/additionalOperations/PURGE/requestBody/content/multipart~1mixed/prefixEncoding/0/headers/X-Prefix/schema",
+                "#/paths/~1events/additionalOperations/PURGE/requestBody/content/multipart~1mixed/itemEncoding/headers/X-Item/schema",
+                "#/paths/~1events/additionalOperations/PURGE/requestBody/content/multipart~1mixed/encoding/envelope/encoding/nested/headers/X-Nested/schema",
+            )
+    }
+}


### PR DESCRIPTION
## Summary

Extends the Fabrikt-owned source model by collecting schema entry points throughout an OpenAPI document and indexing all modelled schemas by their JSON Pointer location.

Schema entry points are collected from components, paths, operations, parameters, headers, request bodies, responses, callbacks, webhooks, media types and encodings.

Collection is version-aware and includes the relevant OpenAPI 3.1 and 3.2 structures, such as reusable path items, webhooks, `query` operations, additional operations, reusable media types, `itemSchema` and nested encoding structures.

## Motivation

The previous source model parsed schemas from `components/schemas`, but schemas can occur in many other parts of an OpenAPI document.

This change provides a complete schema catalogue that future parser and generator work can consume without depending on Kaizen’s document model.

## Compatibility

Existing generators continue to use the Kaizen-backed model.

This PR does not change generated code or existing golden files.

## Testing

Added focused tests covering:

- shared schema locations across OpenAPI 3.0, 3.1 and 3.2;
- parameters, headers, request and response bodies;
- callbacks and webhooks;
- reusable path items;
- OpenAPI 3.2 media types, operations and encodings;
- recursive indexing of nested schemas;
- escaped JSON Pointer locations.

The complete build passes successfully.

Refs #656.