### PR TITLE
Add cookie parameter support

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/GeneratorUtils.kt
@@ -3,6 +3,7 @@ package com.cjbooms.fabrikt.generators
 import com.cjbooms.fabrikt.cli.ControllerCodeGenOptionType
 import com.cjbooms.fabrikt.generators.model.ModelGenerator.Companion.toModelType
 import com.cjbooms.fabrikt.model.BodyParameter
+import com.cjbooms.fabrikt.model.CookieParam
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
@@ -182,6 +183,8 @@ object GeneratorUtils {
 
     fun Operation.getHeaderParams(): List<Parameter> = this.filterParams("header")
 
+    fun Operation.getCookieParams(): List<Parameter> = this.filterParams("cookie")
+
     private fun Operation.getBodyResponses(): List<Response> =
         this.responses
             .filter { it.key != "default" }
@@ -339,6 +342,7 @@ object GeneratorUtils {
         val pathParams: List<RequestParameter>,
         val queryParams: List<RequestParameter>,
         val headerParams: List<RequestParameter>,
+        val cookieParams: List<RequestParameter>,
         val bodyParams: List<BodyParameter>,
     )
 
@@ -349,6 +353,7 @@ object GeneratorUtils {
             pathParams = requestParams.filter { it.parameterLocation is PathParam },
             queryParams = requestParams.filter { it.parameterLocation is QueryParam },
             headerParams = requestParams.filter { it.parameterLocation is HeaderParam },
+            cookieParams = requestParams.filter { it.parameterLocation is CookieParam },
             bodyParams = this.filterIsInstance<BodyParameter>(),
         )
     }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OkHttpSimpleClientGenerator.kt
@@ -21,6 +21,7 @@ import com.cjbooms.fabrikt.generators.model.JacksonMetadata.OBJECT_MAPPER_CLASS
 import com.cjbooms.fabrikt.generators.model.JacksonMetadata.TYPE_REFERENCE_IMPORT
 import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.ClientType
+import com.cjbooms.fabrikt.model.CookieParam
 import com.cjbooms.fabrikt.model.Destinations
 import com.cjbooms.fabrikt.model.GeneratedFile
 import com.cjbooms.fabrikt.model.HeaderParam
@@ -215,9 +216,38 @@ data class SimpleClientOperationStatement(
                     it.name + if (it.typeInfo is KotlinTypeInfo.Enum) "?.value" else "",
                 )
             }
+        addCookieParams()
         this.add("\nadditionalHeaders.forEach { headerBuilder.header(it.key, it.value) }")
 
         return this.add("\nval httpHeaders: %T = headerBuilder.build()\n", "Headers".toClassName("okhttp3"))
+    }
+
+    private fun CodeBlock.Builder.addCookieParams() {
+        val cookieParameters =
+            parameters
+                .filterIsInstance<RequestParameter>()
+                .filter { it.parameterLocation == CookieParam }
+        if (cookieParameters.isEmpty()) return
+
+        add("\nval cookieValues = buildList {")
+        cookieParameters.forEach { parameter ->
+            val receiver = parameter.name + if (parameter.isRequired) "" else "?"
+            when (parameter.typeInfo) {
+                is KotlinTypeInfo.Array ->
+                    if (parameter.explode == false) {
+                        add("\n%L.let { add(%S + it.joinToString(%S)) }", receiver, "${parameter.originalName}=", ",")
+                    } else {
+                        add("\n%L.forEach { add(%S + it) }", receiver, "${parameter.originalName}=")
+                    }
+
+                else -> {
+                    val value = if (parameter.typeInfo is KotlinTypeInfo.Enum) "it.value" else "it"
+                    add("\n%L.let { add(%S + %L) }", receiver, "${parameter.originalName}=", value)
+                }
+            }
+        }
+        add("\n}")
+        add("\nif (cookieValues.isNotEmpty()) headerBuilder.add(%S, cookieValues.joinToString(%S))", "Cookie", "; ")
     }
 
     private fun CodeBlock.Builder.addRequestStatement(): CodeBlock.Builder {

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/OpenFeignInterfaceGenerator.kt
@@ -20,6 +20,7 @@ import com.cjbooms.fabrikt.generators.client.metadata.OpenFeignAnnotations
 import com.cjbooms.fabrikt.generators.client.metadata.OpenFeignImports
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.Clients
+import com.cjbooms.fabrikt.model.CookieParam
 import com.cjbooms.fabrikt.model.GeneratedFile
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.IncomingParameter
@@ -51,8 +52,8 @@ class OpenFeignInterfaceGenerator(
                 .map { (resourceName, paths) ->
                     val funcSpecs: List<FunSpec> =
                         paths.flatMap { (resource, path) ->
-                            path.operations.map { (verb, operation) ->
-                                buildFunction(path, resource, operation, verb, options)
+                            path.operations.flatMap { (verb, operation) ->
+                                buildFunctions(path, resource, operation, verb, options)
                             }
                         }
 
@@ -83,20 +84,66 @@ class OpenFeignInterfaceGenerator(
 
     override fun generateLibrary(options: Set<ClientCodeGenOptionType>): Collection<GeneratedFile> = emptyList()
 
-    private fun buildFunction(
+    private fun buildFunctions(
         path: Path,
         resource: String,
         operation: Operation,
         verb: String,
         options: Set<ClientCodeGenOptionType>,
-    ): FunSpec {
+    ): List<FunSpec> {
         val parameters = deriveClientParameters(path, operation, packages.base)
-        return FunSpec
-            .builder(functionName(operation, resource, verb))
+        val cookieParameters =
+            parameters
+                .filterIsInstance<RequestParameter>()
+                .filter { it.parameterLocation is CookieParam }
+        if (cookieParameters.isEmpty()) {
+            return listOf(buildRequestFunction(operation, resource, verb, options, parameters))
+        }
+
+        val functionName = functionName(operation, resource, verb)
+        val requestFunctionName = "${functionName}WithCookieHeader"
+        val cookieHeaderParameterName =
+            generateSequence("cookieHeader") { previous -> "${previous}Extra" }
+                .first { candidate -> parameters.none { it.name == candidate } }
+        return listOf(
+            buildCookieWrapperFunction(
+                operation,
+                options,
+                parameters,
+                functionName,
+                requestFunctionName,
+                cookieHeaderParameterName,
+                cookieParameters,
+            ),
+            buildRequestFunction(
+                operation,
+                resource,
+                verb,
+                options,
+                parameters.filterNot { it is RequestParameter && it.parameterLocation is CookieParam },
+                requestFunctionName,
+                hasCookieHeader = true,
+                cookieHeaderParameterName = cookieHeaderParameterName,
+            ),
+        )
+    }
+
+    private fun buildRequestFunction(
+        operation: Operation,
+        resource: String,
+        verb: String,
+        options: Set<ClientCodeGenOptionType>,
+        parameters: List<IncomingParameter>,
+        name: String = functionName(operation, resource, verb),
+        hasCookieHeader: Boolean = false,
+        cookieHeaderParameterName: String = "cookieHeader",
+    ): FunSpec =
+        FunSpec
+            .builder(name)
             .addModifiers(KModifier.ABSTRACT)
-            .addKdoc(operation.toKdoc(parameters))
+            .apply { if (!hasCookieHeader) addKdoc(operation.toKdoc(parameters)) }
             .addRequestLineAnnotation(resource, verb, parameters)
-            .addHeadersAnnotation(operation, parameters)
+            .addHeadersAnnotation(operation, parameters, hasCookieHeader, cookieHeaderParameterName)
             .addSuspendModifier(options)
             .addIncomingParameters(
                 parameters,
@@ -106,7 +153,21 @@ class OpenFeignInterfaceGenerator(
                         .addMember("%S", parameter.name)
                         .build()
                 },
-            ).addParameter(
+            ).apply {
+                if (hasCookieHeader) {
+                    addAnnotation(JvmSynthetic::class)
+                    addParameter(
+                        ParameterSpec
+                            .builder(cookieHeaderParameterName, String::class)
+                            .addAnnotation(
+                                OpenFeignAnnotations
+                                    .paramBuilder()
+                                    .addMember("%S", cookieHeaderParameterName)
+                                    .build(),
+                            ).build(),
+                    )
+                }
+            }.addParameter(
                 ParameterSpec
                     .builder(
                         ADDITIONAL_HEADERS_PARAMETER_NAME,
@@ -127,6 +188,102 @@ class OpenFeignInterfaceGenerator(
                     .getReturnType(packages)
                     .optionallyParameterizeWithResponseEntity(options),
             ).build()
+
+    private fun buildCookieWrapperFunction(
+        operation: Operation,
+        options: Set<ClientCodeGenOptionType>,
+        parameters: List<IncomingParameter>,
+        name: String,
+        requestFunctionName: String,
+        cookieHeaderParameterName: String,
+        cookieParameters: List<RequestParameter>,
+    ): FunSpec =
+        FunSpec
+            .builder(name)
+            .addKdoc(operation.toKdoc(parameters))
+            .addSuspendModifier(options)
+            .addIncomingParameters(parameters)
+            .addParameter(
+                ParameterSpec
+                    .builder(
+                        ADDITIONAL_HEADERS_PARAMETER_NAME,
+                        TypeFactory.createMapOfStringToNonNullType(String::class.asTypeName()),
+                    ).defaultValue("emptyMap()")
+                    .build(),
+            ).addParameter(
+                ParameterSpec
+                    .builder(
+                        ADDITIONAL_QUERY_PARAMETERS_PARAMETER_NAME,
+                        TypeFactory.createMapOfStringToNonNullType(String::class.asTypeName()),
+                    ).defaultValue("emptyMap()")
+                    .build(),
+            ).returns(
+                operation
+                    .getReturnType(packages)
+                    .optionallyParameterizeWithResponseEntity(options),
+            ).addCode(
+                buildCodeBlock {
+                    add("return %N(\n", requestFunctionName)
+                    indent()
+                    parameters
+                        .filterNot { it is RequestParameter && it.parameterLocation is CookieParam }
+                        .forEach { add("%N = %N,\n", it.name, it.name) }
+                    add("%N = ", cookieHeaderParameterName)
+                    addCookieHeaderValue(cookieParameters)
+                    add(",\n")
+                    add("%N = %N,\n", ADDITIONAL_HEADERS_PARAMETER_NAME, ADDITIONAL_HEADERS_PARAMETER_NAME)
+                    add("%N = %N,\n", ADDITIONAL_QUERY_PARAMETERS_PARAMETER_NAME, ADDITIONAL_QUERY_PARAMETERS_PARAMETER_NAME)
+                    unindent()
+                    add(")\n")
+                },
+            ).build()
+
+    private fun com.squareup.kotlinpoet.CodeBlock.Builder.addCookieHeaderValue(parameters: List<RequestParameter>) {
+        add("buildList {\n")
+        indent()
+        parameters.forEach { parameter ->
+            val namePrefix = "${parameter.originalName}="
+            when (val typeInfo = parameter.typeInfo) {
+                is KotlinTypeInfo.Array -> {
+                    val itemValue = if (typeInfo.parameterizedType is KotlinTypeInfo.Enum) "it.value" else "it"
+                    if (parameter.explode == false) {
+                        val joined =
+                            if (typeInfo.parameterizedType is KotlinTypeInfo.Enum) {
+                                "%N.joinToString(%S) { it.value }"
+                            } else {
+                                "%N.joinToString(%S)"
+                            }
+                        if (parameter.isRequired) {
+                            add("add(%S + $joined)\n", namePrefix, parameter.name, ",")
+                        } else {
+                            add("%N?.let { values -> add(%S + ", parameter.name, namePrefix)
+                            if (typeInfo.parameterizedType is KotlinTypeInfo.Enum) {
+                                add("values.joinToString(%S) { it.value }", ",")
+                            } else {
+                                add("values.joinToString(%S)", ",")
+                            }
+                            add(") }\n")
+                        }
+                    } else if (parameter.isRequired) {
+                        add("%N.forEach { add(%S + %L) }\n", parameter.name, namePrefix, itemValue)
+                    } else {
+                        add("%N?.forEach { add(%S + %L) }\n", parameter.name, namePrefix, itemValue)
+                    }
+                }
+
+                else -> {
+                    val value = if (typeInfo is KotlinTypeInfo.Enum) "%N.value" else "%N"
+                    if (parameter.isRequired) {
+                        add("add(%S + $value)\n", namePrefix, parameter.name)
+                    } else {
+                        val nullableValue = if (typeInfo is KotlinTypeInfo.Enum) "it.value" else "it"
+                        add("%N?.let { add(%S + %L) }\n", parameter.name, namePrefix, nullableValue)
+                    }
+                }
+            }
+        }
+        unindent()
+        add("}.joinToString(%S)", "; ")
     }
 
     /**
@@ -246,8 +403,10 @@ class OpenFeignInterfaceGenerator(
     private fun FunSpec.Builder.addHeadersAnnotation(
         operation: Operation,
         parameters: List<IncomingParameter>,
+        hasCookieHeader: Boolean,
+        cookieHeaderParameterName: String,
     ): FunSpec.Builder {
-        HeadersAnnotationBuilder(operation, parameters).build()?.let { annotation ->
+        HeadersAnnotationBuilder(operation, parameters, hasCookieHeader, cookieHeaderParameterName).build()?.let { annotation ->
             addAnnotation(annotation)
         }
 
@@ -257,6 +416,8 @@ class OpenFeignInterfaceGenerator(
     private class HeadersAnnotationBuilder(
         private val operation: Operation,
         private val parameters: List<IncomingParameter>,
+        private val hasCookieHeader: Boolean,
+        private val cookieHeaderParameterName: String,
     ) {
         fun build(): AnnotationSpec? {
             val headersValueParts = mutableListOf<String>()
@@ -268,6 +429,7 @@ class OpenFeignInterfaceGenerator(
                     acceptHeaderExists ||
                     parameter.name == ClientGeneratorUtils.ACCEPT_HEADER_NAME
             }
+            if (hasCookieHeader) headersValueParts.add("Cookie: {$cookieHeaderParameterName}")
             // Add default accept header
             if (!acceptHeaderExists) {
                 getDefaultAcceptHeaderAnnotationValue()?.let {

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/SpringHttpInterfaceGenerator.kt
@@ -18,6 +18,7 @@ import com.cjbooms.fabrikt.generators.client.ClientGeneratorUtils.simpleClientNa
 import com.cjbooms.fabrikt.generators.client.metadata.SpringHttpInterfaceAnnotations
 import com.cjbooms.fabrikt.model.ClientType
 import com.cjbooms.fabrikt.model.Clients
+import com.cjbooms.fabrikt.model.CookieParam
 import com.cjbooms.fabrikt.model.Destinations
 import com.cjbooms.fabrikt.model.GeneratedFile
 import com.cjbooms.fabrikt.model.HeaderParam
@@ -103,6 +104,14 @@ class SpringHttpInterfaceGenerator(
                             SpringHttpInterfaceAnnotations
                                 .pathVariableBuilder()
                                 .addMember("%S", parameter.originalName)
+                                .build()
+                        }
+
+                        is CookieParam -> {
+                            SpringHttpInterfaceAnnotations
+                                .cookieValueBuilder()
+                                .addMember("%S", parameter.originalName)
+                                .addMember("required = %L", parameter.isRequired)
                                 .build()
                         }
                     }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/client/metadata/SpringHttpInterface.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/client/metadata/SpringHttpInterface.kt
@@ -11,6 +11,7 @@ object SpringHttpInterfaceImports {
 
     val REQUEST_PARAM = ClassName(Packages.BIND_ANNOTATION, "RequestParam")
     val REQUEST_HEADER = ClassName(Packages.BIND_ANNOTATION, "RequestHeader")
+    val COOKIE_VALUE = ClassName(Packages.BIND_ANNOTATION, "CookieValue")
     val REQUEST_BODY = ClassName(Packages.BIND_ANNOTATION, "RequestBody")
     val PATH_VARIABLE = ClassName(Packages.BIND_ANNOTATION, "PathVariable")
 
@@ -25,6 +26,10 @@ object SpringHttpInterfaceAnnotations {
     fun requestHeaderBuilder(): AnnotationSpec.Builder =
         AnnotationSpec
             .builder(SpringHttpInterfaceImports.REQUEST_HEADER)
+
+    fun cookieValueBuilder(): AnnotationSpec.Builder =
+        AnnotationSpec
+            .builder(SpringHttpInterfaceImports.COOKIE_VALUE)
 
     fun requestBodyBuilder(): AnnotationSpec.Builder =
         AnnotationSpec

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorClientGenerator.kt
@@ -67,7 +67,7 @@ class KtorClientGenerator(
                                 emptyList(),
                             )
 
-                        val (pathParams, queryParams, headerParams, bodyParams) = params.splitByType()
+                        val (pathParams, queryParams, headerParams, cookieParams, bodyParams) = params.splitByType()
 
                         val responseType = operation.toSuccessResponseType(packages.base)
                         val returnType = networkResultClassName.parameterizedBy(responseType)
@@ -166,6 +166,93 @@ class KtorClientGenerator(
                                                     it.name,
                                                 )
                                             }
+                                            cookieParams.forEach { parameter ->
+                                                val cookieFunction = MemberName("io.ktor.client.request", "cookie")
+                                                when (parameter.typeInfo) {
+                                                    is KotlinTypeInfo.Array -> {
+                                                        val itemValue =
+                                                            if (parameter.typeInfo.parameterizedType is KotlinTypeInfo.Enum) {
+                                                                "it.value"
+                                                            } else {
+                                                                "it.toString()"
+                                                            }
+                                                        if (parameter.explode == false) {
+                                                            if (parameter.isRequired) {
+                                                                if (parameter.typeInfo.parameterizedType is KotlinTypeInfo.Enum) {
+                                                                    addStatement(
+                                                                        "%M(%S, %N.joinToString(%S) { it.value })",
+                                                                        cookieFunction,
+                                                                        parameter.originalName,
+                                                                        parameter.name,
+                                                                        ",",
+                                                                    )
+                                                                } else {
+                                                                    addStatement(
+                                                                        "%M(%S, %N.joinToString(%S))",
+                                                                        cookieFunction,
+                                                                        parameter.originalName,
+                                                                        parameter.name,
+                                                                        ",",
+                                                                    )
+                                                                }
+                                                            } else {
+                                                                if (parameter.typeInfo.parameterizedType is KotlinTypeInfo.Enum) {
+                                                                    addStatement(
+                                                                        "%N?.let { values -> %M(%S, values.joinToString(%S) { it.value }) }",
+                                                                        parameter.name,
+                                                                        cookieFunction,
+                                                                        parameter.originalName,
+                                                                        ",",
+                                                                    )
+                                                                } else {
+                                                                    addStatement(
+                                                                        "%N?.let { %M(%S, it.joinToString(%S)) }",
+                                                                        parameter.name,
+                                                                        cookieFunction,
+                                                                        parameter.originalName,
+                                                                        ",",
+                                                                    )
+                                                                }
+                                                            }
+                                                        } else if (parameter.isRequired) {
+                                                            addStatement(
+                                                                "%N.forEach { %M(%S, %L) }",
+                                                                parameter.name,
+                                                                cookieFunction,
+                                                                parameter.originalName,
+                                                                itemValue,
+                                                            )
+                                                        } else {
+                                                            addStatement(
+                                                                "%N?.forEach { %M(%S, %L) }",
+                                                                parameter.name,
+                                                                cookieFunction,
+                                                                parameter.originalName,
+                                                                itemValue,
+                                                            )
+                                                        }
+                                                    }
+
+                                                    else ->
+                                                        if (parameter.isRequired) {
+                                                            addStatement(
+                                                                "%M(%S, %N%L)",
+                                                                cookieFunction,
+                                                                parameter.originalName,
+                                                                parameter.name,
+                                                                if (parameter.typeInfo is KotlinTypeInfo.Enum) ".value" else ".toString()",
+                                                            )
+                                                        } else {
+                                                            addStatement(
+                                                                "%N?.let { %M(%S, it%L) }",
+                                                                parameter.name,
+                                                                cookieFunction,
+                                                                parameter.originalName,
+                                                                if (parameter.typeInfo is KotlinTypeInfo.Enum) ".value" else ".toString()",
+                                                            )
+                                                        }
+                                                }
+                                            }
 
                                             addStatement("%M {", MemberName("io.ktor.client.request", "headers"))
                                             indent()
@@ -257,7 +344,7 @@ class KtorClientGenerator(
                                     .build(),
                             )
                         }
-                        (pathParams + queryParams + headerParams).forEach { param ->
+                        (pathParams + queryParams + headerParams + cookieParams).forEach { param ->
                             val defaultValue = if (!param.isRequired) "null" else null
                             clientFunctionBuilder.addParameter(
                                 ParameterSpec
@@ -326,7 +413,7 @@ class KtorClientGenerator(
         operation: Operation,
         parameters: List<IncomingParameter>,
     ): CodeBlock {
-        val (pathParams, queryParams, headerParams, bodyParams) = parameters.splitByType()
+        val (pathParams, queryParams, headerParams, cookieParams, bodyParams) = parameters.splitByType()
         val kDoc = CodeBlock.builder()
 
         // add summary and description
@@ -339,7 +426,7 @@ class KtorClientGenerator(
         // document parameters
         if (parameters.isNotEmpty()) {
             kDoc.add("Parameters:\n")
-            (bodyParams + pathParams + queryParams + headerParams).forEach {
+            (bodyParams + pathParams + queryParams + headerParams + cookieParams).forEach {
                 kDoc.add("\t @param %L %L\n", it.name.toKCodeName(), it.description?.trimIndent().orEmpty()).build()
             }
         }

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/KtorControllerInterfaceGenerator.kt
@@ -10,15 +10,11 @@ import com.cjbooms.fabrikt.generators.GeneratorUtils.toKCodeName
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.SecuritySupport
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.securitySupport
 import com.cjbooms.fabrikt.generators.controller.ControllerGeneratorUtils.toSuccessResponseType
-import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.ControllerType
-import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.IncomingParameter
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.KotlinTypes
-import com.cjbooms.fabrikt.model.PathParam
-import com.cjbooms.fabrikt.model.QueryParam
 import com.cjbooms.fabrikt.model.RequestParameter
 import com.cjbooms.fabrikt.model.SourceApi
 import com.cjbooms.fabrikt.util.FileUtils.addFileDisclaimer
@@ -131,9 +127,9 @@ class KtorControllerInterfaceGenerator(
                 .addModifiers(setOf(KModifier.SUSPEND, KModifier.ABSTRACT))
 
         val params = operation.toIncomingParameters(packages.base, path.value.parameters, emptyList())
-        val (pathParams, queryParams, headerParams, bodyParams) = params.splitByType()
+        val (pathParams, queryParams, headerParams, cookieParams, bodyParams) = params.splitByType()
 
-        headerParams.forEach { param ->
+        (headerParams + cookieParams).forEach { param ->
             // TODO: Consider handling header parameter types. Currently everything is a string.
             if (param.isRequired) {
                 builder.addParameter(ParameterSpec.builder(param.name, String::class).build())
@@ -211,7 +207,7 @@ class KtorControllerInterfaceGenerator(
         }
 
         val params = operation.toIncomingParameters(packages.base, path.value.parameters, emptyList())
-        val (pathParams, queryParams, headerParams, bodyParams) = params.splitByType()
+        val (pathParams, queryParams, headerParams, cookieParams, bodyParams) = params.splitByType()
 
         val methodName = getMethodName(operation, verb, path)
 
@@ -255,6 +251,21 @@ class KtorControllerInterfaceGenerator(
             }
         }
 
+        cookieParams.forEach { param ->
+            if (param.isRequired) {
+                builder.addStatement(
+                    "val ${param.name} = %M.request.cookies[\"${param.originalName}\"] ?: throw %M(\"${param.originalName}\")",
+                    MemberName("io.ktor.server.application", "call"),
+                    MemberName("io.ktor.server.plugins", "MissingRequestParameterException"),
+                )
+            } else {
+                builder.addStatement(
+                    "val ${param.name} = %M.request.cookies[\"${param.originalName}\"]",
+                    MemberName("io.ktor.server.application", "call"),
+                )
+            }
+        }
+
         queryParams.forEach { param ->
             val typeName = param.type.copy(nullable = false) // not nullable because we handle that in the queryParameters.get* below
             val queryMethodName = if (param.isRequired) "getTypedOrFail" else "getTyped"
@@ -285,7 +296,7 @@ class KtorControllerInterfaceGenerator(
         }
 
         val methodParameters =
-            listOf(headerParams, pathParams, queryParams, bodyParams)
+            listOf(headerParams, cookieParams, pathParams, queryParams, bodyParams)
                 .asSequence()
                 .flatten()
                 .map { it.name }
@@ -593,24 +604,6 @@ class KtorControllerInterfaceGenerator(
             }
     }
 }
-
-private fun List<IncomingParameter>.splitByType(): IncomingParametersByType {
-    val requestParams = this.filterIsInstance<RequestParameter>()
-
-    return IncomingParametersByType(
-        pathParams = requestParams.filter { it.parameterLocation is PathParam },
-        queryParams = requestParams.filter { it.parameterLocation is QueryParam },
-        headerParams = requestParams.filter { it.parameterLocation is HeaderParam },
-        bodyParams = this.filterIsInstance<BodyParameter>(),
-    )
-}
-
-private data class IncomingParametersByType(
-    val pathParams: List<RequestParameter>,
-    val queryParams: List<RequestParameter>,
-    val headerParams: List<RequestParameter>,
-    val bodyParams: List<BodyParameter>,
-)
 
 private fun TypeName.isUnit(): Boolean = this == Unit::class.asTypeName()
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/MicronautControllerInterfaceGenerator.kt
@@ -16,6 +16,7 @@ import com.cjbooms.fabrikt.generators.controller.metadata.MicronautImports.SECUR
 import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.ControllerType
+import com.cjbooms.fabrikt.model.CookieParam
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.KotlinTypes
 import com.cjbooms.fabrikt.model.MultipartParameter
@@ -239,6 +240,10 @@ class MicronautControllerInterfaceGenerator(
             PathParam ->
                 AnnotationSpec
                     .builder(MicronautImports.PATH_VARIABLE)
+
+            CookieParam ->
+                AnnotationSpec
+                    .builder(MicronautImports.COOKIE_VALUE)
         }.let {
             it.addMember("value = %S", parameter.oasName)
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/SpringControllerInterfaceGenerator.kt
@@ -15,6 +15,7 @@ import com.cjbooms.fabrikt.generators.controller.metadata.SpringImports
 import com.cjbooms.fabrikt.model.BodyParameter
 import com.cjbooms.fabrikt.model.ControllerLibraryType
 import com.cjbooms.fabrikt.model.ControllerType
+import com.cjbooms.fabrikt.model.CookieParam
 import com.cjbooms.fabrikt.model.HeaderParam
 import com.cjbooms.fabrikt.model.KotlinTypeInfo
 import com.cjbooms.fabrikt.model.KotlinTypes
@@ -210,6 +211,7 @@ class SpringControllerInterfaceGenerator(
             QueryParam -> SpringAnnotations.requestParamBuilder()
             HeaderParam -> SpringAnnotations.requestHeaderBuilder()
             PathParam -> SpringAnnotations.requestPathVariableBuilder()
+            CookieParam -> SpringAnnotations.cookieValueBuilder()
         }.let {
             it.addMember("value = %S", parameter.oasName)
             it.addMember("required = %L", parameter.isRequired)

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/metadata/MicronautImports.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/metadata/MicronautImports.kt
@@ -34,6 +34,7 @@ object MicronautImports {
     val CONTROLLER = ClassName(Packages.MICRONAUT_HTTP_ANNOTATION, "Controller")
     val BODY = ClassName(Packages.MICRONAUT_HTTP_ANNOTATION, "Body")
     val HEADER = ClassName(Packages.MICRONAUT_HTTP_ANNOTATION, "Header")
+    val COOKIE_VALUE = ClassName(Packages.MICRONAUT_HTTP_ANNOTATION, "CookieValue")
     val QUERY_VALUE = ClassName(Packages.MICRONAUT_HTTP_ANNOTATION, "QueryValue")
     val PATH_VARIABLE = ClassName(Packages.MICRONAUT_HTTP_ANNOTATION, "PathVariable")
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/metadata/Spring.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/generators/controller/metadata/Spring.kt
@@ -30,6 +30,8 @@ object SpringImports {
 
     val REQUEST_HEADER = ClassName(Packages.WEB_BIND_ANNOTATION, "RequestHeader")
 
+    val COOKIE_VALUE = ClassName(Packages.WEB_BIND_ANNOTATION, "CookieValue")
+
     val REQUEST_BODY = ClassName(Packages.WEB_BIND_ANNOTATION, "RequestBody")
 
     val REQUEST_PART = ClassName(Packages.WEB_BIND_ANNOTATION, "RequestPart")
@@ -87,6 +89,10 @@ object SpringAnnotations {
     fun requestHeaderBuilder(): AnnotationSpec.Builder =
         AnnotationSpec
             .builder(SpringImports.REQUEST_HEADER)
+
+    fun cookieValueBuilder(): AnnotationSpec.Builder =
+        AnnotationSpec
+            .builder(SpringImports.COOKIE_VALUE)
 
     fun requestBodyBuilder(): AnnotationSpec.Builder =
         AnnotationSpec

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/KotlinGenModels.kt
@@ -158,6 +158,13 @@ class RequestParameter(
     val explode: Boolean? = null,
     val defaultValue: Any? = null,
 ) : IncomingParameter(oasName, description, type, isRequired) {
+    init {
+        require(parameterLocation !is CookieParam || typeInfo.supportsCookieSerialization()) {
+            "Cookie parameter '$originalName' has an unsupported type. " +
+                "Cookie parameters support scalar values, enums, and arrays of those types."
+        }
+    }
+
     constructor(oasName: String, description: String?, type: TypeName, parameter: Parameter) : this(
         oasName = oasName,
         description = description,
@@ -189,3 +196,24 @@ class RequestParameter(
             super.toParameterSpecBuilder(treatAnyTypeHeadersAsStrings)
         }
 }
+
+private fun KotlinTypeInfo.supportsCookieSerialization(): Boolean =
+    when (this) {
+        KotlinTypeInfo.AnyType,
+        KotlinTypeInfo.ByteArray,
+        KotlinTypeInfo.InputStream,
+        KotlinTypeInfo.JsonElement,
+        KotlinTypeInfo.JsonObject,
+        KotlinTypeInfo.UnknownAdditionalProperties,
+        KotlinTypeInfo.UntypedObject,
+        KotlinTypeInfo.UntypedObjectAdditionalProperties,
+        is KotlinTypeInfo.GeneratedTypedAdditionalProperties,
+        is KotlinTypeInfo.Map,
+        is KotlinTypeInfo.MapTypeAdditionalProperties,
+        is KotlinTypeInfo.Object,
+        is KotlinTypeInfo.SimpleTypedAdditionalProperties,
+        -> false
+
+        is KotlinTypeInfo.Array -> parameterizedType.supportsCookieSerialization() && parameterizedType !is KotlinTypeInfo.Array
+        else -> true
+    }

--- a/src/main/kotlin/com/cjbooms/fabrikt/model/ParameterInfo.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/model/ParameterInfo.kt
@@ -7,6 +7,7 @@ sealed class RequestParameterLocation {
                 "query" -> QueryParam
                 "header" -> HeaderParam
                 "path" -> PathParam
+                "cookie" -> CookieParam
                 else -> throw IllegalStateException("Invalid request parameter location: $location")
             }
     }
@@ -22,4 +23,8 @@ object HeaderParam : RequestParameterLocation() {
 
 object PathParam : RequestParameterLocation() {
     override fun toString() = "path"
+}
+
+object CookieParam : RequestParameterLocation() {
+    override fun toString() = "cookie"
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorClientGeneratorTest.kt
@@ -30,7 +30,7 @@ class KtorClientGeneratorTest {
         )
 
     @Suppress("unused")
-    private fun groupedClientTestCases(): Stream<String> = Stream.concat(fullApiTestCases(), Stream.of("tagGrouping"))
+    private fun groupedClientTestCases(): Stream<String> = Stream.concat(fullApiTestCases(), Stream.of("tagGrouping", "cookieParameters"))
 
     @BeforeEach
     fun init() {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/KtorControllerInterfaceGeneratorTest.kt
@@ -47,6 +47,7 @@ class KtorControllerInterfaceGeneratorTest {
             "queryParameters",
             "pathParameters",
             "tagGrouping",
+            "cookieParameters",
         )
 
     private fun setupGithubApiTestEnv() {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/MicronautControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/MicronautControllerGeneratorTest.kt
@@ -47,6 +47,7 @@ class MicronautControllerGeneratorTest {
             "jakartaValidationAnnotations",
             "modelSuffix",
             "tagGrouping",
+            "cookieParameters",
         )
 
     private fun setupGithubApiTestEnv(validationAnnotations: ValidationAnnotations = JavaxValidationAnnotations) {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OkHttpClientGeneratorTest.kt
@@ -47,7 +47,7 @@ class OkHttpClientGeneratorTest {
         )
 
     @Suppress("unused")
-    private fun groupedClientTestCases(): Stream<String> = Stream.concat(fullApiTestCases(), Stream.of("tagGrouping"))
+    private fun groupedClientTestCases(): Stream<String> = Stream.concat(fullApiTestCases(), Stream.of("tagGrouping", "cookieParameters"))
 
     @BeforeEach
     fun init() {
@@ -117,7 +117,7 @@ class OkHttpClientGeneratorTest {
                 .contentOf("HttpResilience4jUtil.kt")
         val enhancedClientCode = generator.generateDynamicClientCode(options)
 
-        if (testCaseName != "tagGrouping") {
+        if (testCaseName != "tagGrouping" && testCaseName != "cookieParameters") {
             assertThatGenerated(enhancedLibUtil).isEqualTo(expectedLibUtil)
         }
         assertThatGenerated(enhancedClientCode.toSingleFile()).isEqualTo(expectedClientCode)

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/OpenFeignClientGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/OpenFeignClientGeneratorTest.kt
@@ -32,6 +32,7 @@ class OpenFeignClientGeneratorTest {
             "pathLevelParameters",
             "parameterNameClash",
             "tagGrouping",
+            "cookieParameters",
         )
 
     @BeforeEach

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringControllerGeneratorTest.kt
@@ -56,6 +56,7 @@ class SpringControllerGeneratorTest {
             "responsesSchema",
             "multipartUpload",
             "validationAnnotations",
+            "cookieParameters",
         )
 
     private fun setupGithubApiTestEnv(annotations: ValidationAnnotations = JavaxValidationAnnotations) {

--- a/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringHttpInterfaceGeneratorTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/generators/SpringHttpInterfaceGeneratorTest.kt
@@ -36,6 +36,7 @@ class SpringHttpInterfaceGeneratorTest {
             "pathLevelParameters",
             "parameterNameClash",
             "tagGrouping",
+            "cookieParameters",
         )
 
     @BeforeEach

--- a/src/test/kotlin/com/cjbooms/fabrikt/model/RequestParameterTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/model/RequestParameterTest.kt
@@ -1,0 +1,30 @@
+package com.cjbooms.fabrikt.model
+
+import com.squareup.kotlinpoet.ClassName
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class RequestParameterTest {
+    @Test
+    fun `supports scalar cookie parameters`() {
+        assertThatCode { requestParameter(KotlinTypeInfo.Text) }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `rejects cookie parameters that cannot be serialized safely`() {
+        assertThatThrownBy { requestParameter(KotlinTypeInfo.Object("Preferences")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Cookie parameter 'preferences' has an unsupported type")
+    }
+
+    private fun requestParameter(typeInfo: KotlinTypeInfo) =
+        RequestParameter(
+            oasName = "preferences",
+            description = null,
+            type = ClassName("example", "Preferences"),
+            originalName = "preferences",
+            parameterLocation = CookieParam,
+            typeInfo = typeInfo,
+        )
+}

--- a/src/test/resources/examples/cookieParameters/api.yaml
+++ b/src/test/resources/examples/cookieParameters/api.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.3
+info:
+  title: Cookie parameters
+  version: 1.0.0
+paths:
+  /cookies/{id}:
+    get:
+      operationId: getCookiePreferences
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: sessionId
+          in: cookie
+          required: true
+          schema:
+            type: string
+        - name: locale
+          in: cookie
+          schema:
+            type: string
+        - name: displayMode
+          in: cookie
+          required: true
+          schema:
+            type: string
+            enum:
+              - compact
+              - detailed
+        - name: features
+          in: cookie
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: scopes
+          in: cookie
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: Cookie preferences
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CookiePreferences'
+components:
+  schemas:
+    CookiePreferences:
+      type: object
+      required:
+        - locale
+      properties:
+        locale:
+          type: string

--- a/src/test/resources/examples/cookieParameters/client/ApiClient.kt
+++ b/src/test/resources/examples/cookieParameters/client/ApiClient.kt
@@ -1,0 +1,76 @@
+package examples.cookieParameters.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import examples.cookieParameters.models.CookiePreferences
+import examples.cookieParameters.models.DisplayMode
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+@Suppress("unused")
+public class CookiesClient(
+    private val objectMapper: ObjectMapper,
+    private val baseUrl: String,
+    private val okHttpClient: OkHttpClient,
+) {
+    /**
+     *
+     *
+     * @param id
+     * @param sessionId
+     * @param displayMode
+     * @param features
+     * @param locale
+     * @param scopes
+     */
+    @Throws(ApiException::class)
+    public fun getCookiePreferences(
+        id: String,
+        sessionId: String,
+        displayMode: DisplayMode,
+        features: List<String>,
+        locale: String? = null,
+        scopes: List<String>? = null,
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): ApiResponse<CookiePreferences> {
+        val httpUrl: HttpUrl =
+            "$baseUrl/cookies/{id}"
+                .pathParam("{id}" to id)
+                .toHttpUrl()
+                .newBuilder()
+                .also { builder -> additionalQueryParameters.forEach { builder.queryParam(it.key, it.value) } }
+                .build()
+
+        val headerBuilder = Headers.Builder()
+        val cookieValues =
+            buildList {
+                sessionId.let { add("sessionId=" + it) }
+                displayMode.let { add("displayMode=" + it.value) }
+                features.forEach { add("features=" + it) }
+                locale?.let { add("locale=" + it) }
+                scopes?.let { add("scopes=" + it.joinToString(",")) }
+            }
+        if (cookieValues.isNotEmpty()) headerBuilder.add("Cookie", cookieValues.joinToString("; "))
+        additionalHeaders.forEach { headerBuilder.header(it.key, it.value) }
+        val httpHeaders: Headers = headerBuilder.build()
+
+        val request: Request =
+            Request
+                .Builder()
+                .url(httpUrl)
+                .headers(httpHeaders)
+                .get()
+                .build()
+
+        return request.execute(okHttpClient, objectMapper, jacksonTypeRef())
+    }
+}

--- a/src/test/resources/examples/cookieParameters/client/ApiService.kt
+++ b/src/test/resources/examples/cookieParameters/client/ApiService.kt
@@ -1,0 +1,47 @@
+package examples.cookieParameters.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import examples.cookieParameters.models.CookiePreferences
+import examples.cookieParameters.models.DisplayMode
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import okhttp3.OkHttpClient
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.jvm.Throws
+
+/**
+ * The circuit breaker registry should have the proper configuration to correctly action on circuit
+ * breaker transitions based on the client exceptions [ApiClientException], [ApiServerException] and
+ * [IOException].
+ *
+ * @see ApiClientException
+ * @see ApiServerException
+ */
+@Suppress("unused")
+public class CookiesService(
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+    objectMapper: ObjectMapper,
+    baseUrl: String,
+    okHttpClient: OkHttpClient,
+) {
+    public var circuitBreakerName: String = "cookiesClient"
+
+    private val apiClient: CookiesClient = CookiesClient(objectMapper, baseUrl, okHttpClient)
+
+    @Throws(ApiException::class)
+    public fun getCookiePreferences(
+        id: String,
+        sessionId: String,
+        displayMode: DisplayMode,
+        features: List<String>,
+        locale: String? = null,
+        scopes: List<String>? = null,
+        additionalHeaders: Map<String, String> = emptyMap(),
+    ): ApiResponse<CookiePreferences> =
+        withCircuitBreaker(circuitBreakerRegistry, circuitBreakerName) {
+            apiClient.getCookiePreferences(id, sessionId, displayMode, features, locale, scopes, additionalHeaders)
+        }
+}

--- a/src/test/resources/examples/cookieParameters/client/OpenFeignClient.kt
+++ b/src/test/resources/examples/cookieParameters/client/OpenFeignClient.kt
@@ -1,0 +1,64 @@
+package examples.cookieParameters.client
+
+import examples.cookieParameters.models.CookiePreferences
+import examples.cookieParameters.models.DisplayMode
+import feign.HeaderMap
+import feign.Headers
+import feign.Param
+import feign.QueryMap
+import feign.RequestLine
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.jvm.JvmSynthetic
+
+@Suppress("unused")
+public interface CookiesClient {
+    /**
+     *
+     *
+     * @param id
+     * @param sessionId
+     * @param displayMode
+     * @param features
+     * @param locale
+     * @param scopes
+     */
+    public fun getCookiePreferences(
+        id: String,
+        sessionId: String,
+        displayMode: DisplayMode,
+        features: List<String>,
+        locale: String? = null,
+        scopes: List<String>? = null,
+        additionalHeaders: Map<String, String> = emptyMap(),
+        additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): CookiePreferences =
+        getCookiePreferencesWithCookieHeader(
+            id = id,
+            cookieHeader =
+                buildList {
+                    add("sessionId=" + sessionId)
+                    add("displayMode=" + displayMode.value)
+                    features.forEach { add("features=" + it) }
+                    locale?.let { add("locale=" + it) }
+                    scopes?.let { values -> add("scopes=" + values.joinToString(",")) }
+                }.joinToString("; "),
+            additionalHeaders = additionalHeaders,
+            additionalQueryParameters = additionalQueryParameters,
+        )
+
+    @RequestLine("GET /cookies/{id}")
+    @Headers(
+        "Cookie: {cookieHeader}",
+        "Accept: application/json",
+    )
+    @JvmSynthetic
+    public fun getCookiePreferencesWithCookieHeader(
+        @Param("id") id: String,
+        @Param("cookieHeader") cookieHeader: String,
+        @HeaderMap additionalHeaders: Map<String, String> = emptyMap(),
+        @QueryMap additionalQueryParameters: Map<String, String> = emptyMap(),
+    ): CookiePreferences
+}

--- a/src/test/resources/examples/cookieParameters/client/SpringHttpInterfaceClient.kt
+++ b/src/test/resources/examples/cookieParameters/client/SpringHttpInterfaceClient.kt
@@ -1,0 +1,43 @@
+package examples.cookieParameters.client
+
+import examples.cookieParameters.models.CookiePreferences
+import examples.cookieParameters.models.DisplayMode
+import org.springframework.web.bind.`annotation`.CookieValue
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.RequestHeader
+import org.springframework.web.bind.`annotation`.RequestParam
+import org.springframework.web.service.`annotation`.HttpExchange
+import kotlin.Any
+import kotlin.String
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.Map
+
+@Suppress("unused")
+public interface CookiesClient {
+    /**
+     *
+     *
+     * @param id
+     * @param sessionId
+     * @param displayMode
+     * @param features
+     * @param locale
+     * @param scopes
+     */
+    @HttpExchange(
+        url = "/cookies/{id}",
+        method = "GET",
+        accept = ["application/json"],
+    )
+    public fun getCookiePreferences(
+        @PathVariable("id") id: String,
+        @CookieValue("sessionId", required = true) sessionId: String,
+        @CookieValue("displayMode", required = true) displayMode: DisplayMode,
+        @CookieValue("features", required = true) features: List<String>,
+        @CookieValue("locale", required = false) locale: String? = null,
+        @CookieValue("scopes", required = false) scopes: List<String>? = null,
+        @RequestHeader additionalHeaders: Map<String, Any> = emptyMap(),
+        @RequestParam additionalQueryParameters: Map<String, Any> = emptyMap(),
+    ): CookiePreferences
+}

--- a/src/test/resources/examples/cookieParameters/client/ktor/KtorClient.kt
+++ b/src/test/resources/examples/cookieParameters/client/ktor/KtorClient.kt
@@ -1,0 +1,95 @@
+package examples.cookieParameters.client
+
+import examples.cookieParameters.models.CookiePreferences
+import examples.cookieParameters.models.DisplayMode
+import io.ktor.client.HttpClient
+import io.ktor.client.call.NoTransformationFoundException
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.request.cookie
+import io.ktor.client.request.`get`
+import io.ktor.client.request.`header`
+import io.ktor.client.request.headers
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import io.ktor.serialization.ContentConvertException
+import kotlinx.coroutines.CancellationException
+import kotlinx.io.IOException
+import kotlin.String
+import kotlin.collections.List
+
+public class CookiesClient(
+    private val httpClient: HttpClient,
+) {
+    /**
+     * Parameters:
+     * 	 @param id
+     * 	 @param sessionId
+     * 	 @param displayMode
+     * 	 @param features
+     * 	 @param locale
+     * 	 @param scopes
+     *
+     * Returns:
+     * 	[NetworkResult.Success] with [examples.cookieParameters.models.CookiePreferences] if the
+     * request was successful.
+     * 	[NetworkResult.Failure] with a [NetworkError] if the request failed.
+     */
+    public suspend fun getCookiePreferences(
+        id: String,
+        sessionId: String,
+        displayMode: DisplayMode,
+        features: List<String>,
+        locale: String? = null,
+        scopes: List<String>? = null,
+        apiConfiguration: ApiConfiguration = ApiConfiguration(),
+    ): NetworkResult<CookiePreferences> {
+        val basePath = apiConfiguration.basePath.trimEnd('/')
+        val url = basePath + """/cookies/$id"""
+
+        return try {
+            val response =
+                httpClient.`get`(url) {
+                    `header`("Accept", "application/json")
+                    cookie("sessionId", sessionId.toString())
+                    cookie("displayMode", displayMode.value)
+                    features.forEach { cookie("features", it.toString()) }
+                    locale?.let { cookie("locale", it.toString()) }
+                    scopes?.let { cookie("scopes", it.joinToString(",")) }
+                    headers {
+                        apiConfiguration.customHeaders.forEach { (name, value) ->
+                            remove(name)
+                            append(name, value)
+                        }
+                    }
+                }
+
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(response.body())
+            } else {
+                val errorBody = response.bodyAsText().ifBlank { null }
+                NetworkResult.Failure(
+                    NetworkError.Http(
+                        statusCode = response.status.value,
+                        statusDescription = response.status.description,
+                        body = errorBody,
+                    ),
+                )
+            }
+        } catch (e: ResponseException) {
+            val status = e.response.status
+            val body = runCatching { e.response.bodyAsText() }.getOrNull()?.ifBlank { null }
+            NetworkResult.Failure(NetworkError.Http(status.value, status.description, body))
+        } catch (e: IOException) {
+            NetworkResult.Failure(NetworkError.Network(e))
+        } catch (e: ContentConvertException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: NoTransformationFoundException) {
+            NetworkResult.Failure(NetworkError.Serialization(e))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            NetworkResult.Failure(NetworkError.Unknown(e))
+        }
+    }
+}

--- a/src/test/resources/examples/cookieParameters/controllers/ktor/Controllers.kt
+++ b/src/test/resources/examples/cookieParameters/controllers/ktor/Controllers.kt
@@ -1,0 +1,165 @@
+package examples.cookieParameters.controllers
+
+import examples.cookieParameters.models.CookiePreferences
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.MissingRequestParameterException
+import io.ktor.server.plugins.ParameterConversionException
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.`get`
+import io.ktor.util.converters.ConversionService
+import io.ktor.util.converters.DefaultConversionService
+import io.ktor.util.reflect.typeInfo
+import kotlin.Any
+import kotlin.String
+import kotlin.Suppress
+
+public interface CookiesController {
+    /**
+     * Route is expected to respond with [examples.cookieParameters.models.CookiePreferences].
+     * Use [examples.cookieParameters.controllers.TypedApplicationCall.respondTyped] to send the
+     * response.
+     *
+     * @param id
+     * @param sessionId
+     * @param displayMode
+     * @param features
+     * @param locale
+     * @param scopes
+     * @param call Decorated ApplicationCall with additional typed respond methods
+     */
+    public suspend fun getCookiePreferences(
+        sessionId: String,
+        displayMode: String,
+        features: String,
+        locale: String?,
+        scopes: String?,
+        id: String,
+        call: TypedApplicationCall<CookiePreferences>,
+    )
+
+    public companion object {
+        /**
+         * Mounts all routes for the Cookies resource
+         *
+         * - GET /cookies/{id}
+         */
+        public fun Route.cookiesRoutes(controller: CookiesController) {
+            `get`("/cookies/{id}") {
+                val id = call.parameters.getTypedOrFail<kotlin.String>("id")
+                val sessionId =
+                    call.request.cookies["sessionId"] ?: throw
+                        MissingRequestParameterException("sessionId")
+                val displayMode =
+                    call.request.cookies["displayMode"] ?: throw
+                        MissingRequestParameterException("displayMode")
+                val features =
+                    call.request.cookies["features"] ?: throw
+                        MissingRequestParameterException("features")
+                val locale = call.request.cookies["locale"]
+                val scopes = call.request.cookies["scopes"]
+                controller.getCookiePreferences(
+                    sessionId,
+                    displayMode,
+                    features,
+                    locale,
+                    scopes,
+                    id,
+                    TypedApplicationCall(call),
+                )
+            }
+        }
+
+        /**
+         * Gets parameter value associated with this name or null if the name is not present.
+         * Converting to type R using ConversionService.
+         *
+         * Throws:
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTyped(
+            name: String,
+            conversionService: ConversionService = DefaultConversionService,
+        ): R? {
+            val values = getAll(name) ?: return null
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                conversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets parameter value associated with this name or throws if the name is not present.
+         * Converting to type R using ConversionService.
+         *
+         * Throws:
+         *   MissingRequestParameterException - when parameter is missing
+         *   ParameterConversionException - when conversion from String to R fails
+         */
+        private inline fun <reified R : Any> Parameters.getTypedOrFail(
+            name: String,
+            conversionService: ConversionService = DefaultConversionService,
+        ): R {
+            val values = getAll(name) ?: throw MissingRequestParameterException(name)
+            val typeInfo = typeInfo<R>()
+            return try {
+                @Suppress("UNCHECKED_CAST")
+                conversionService.fromValues(values, typeInfo) as R
+            } catch (cause: Exception) {
+                throw ParameterConversionException(
+                    name,
+                    typeInfo.type.simpleName
+                        ?: typeInfo.type.toString(),
+                    cause,
+                )
+            }
+        }
+
+        /**
+         * Gets first value from the list of values associated with a name.
+         *
+         * Throws:
+         *   BadRequestException - when the name is not present
+         */
+        private fun Headers.getOrFail(name: String): String =
+            this[name] ?: throw
+                BadRequestException("Header " + name + " is required")
+    }
+}
+
+/**
+ * Decorator for Ktor's ApplicationCall that provides type safe variants of the [respond] functions.
+ *
+ * It can be used as a drop-in replacement for [io.ktor.server.application.ApplicationCall].
+ *
+ * @param R The type of the response body
+ */
+public class TypedApplicationCall<R : Any>(
+    private val applicationCall: ApplicationCall,
+) : ApplicationCall by applicationCall {
+    @Suppress("unused")
+    public suspend inline fun <reified T : R> respondTyped(message: T) {
+        respond(message)
+    }
+
+    @Suppress("unused")
+    public suspend inline fun <reified T : R> respondTyped(
+        status: HttpStatusCode,
+        message: T,
+    ) {
+        respond(status, message)
+    }
+}

--- a/src/test/resources/examples/cookieParameters/controllers/micronaut/Controllers.kt
+++ b/src/test/resources/examples/cookieParameters/controllers/micronaut/Controllers.kt
@@ -1,0 +1,38 @@
+package examples.cookieParameters.controllers
+
+import examples.cookieParameters.models.CookiePreferences
+import examples.cookieParameters.models.DisplayMode
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.`annotation`.Controller
+import io.micronaut.http.`annotation`.CookieValue
+import io.micronaut.http.`annotation`.Get
+import io.micronaut.http.`annotation`.PathVariable
+import io.micronaut.http.`annotation`.Produces
+import io.micronaut.security.rules.SecurityRule
+import javax.validation.Valid
+import kotlin.String
+import kotlin.collections.List
+
+@Controller
+public interface CookiesController {
+    /**
+     *
+     *
+     * @param id
+     * @param sessionId
+     * @param displayMode
+     * @param features
+     * @param locale
+     * @param scopes
+     */
+    @Get(uri = "/cookies/{id}")
+    @Produces(value = ["application/json"])
+    public fun getCookiePreferences(
+        @PathVariable(value = "id") id: String,
+        @CookieValue(value = "sessionId") sessionId: String,
+        @CookieValue(value = "displayMode") displayMode: DisplayMode,
+        @Valid @CookieValue(value = "features") features: List<String>,
+        @CookieValue(value = "locale") locale: String?,
+        @Valid @CookieValue(value = "scopes") scopes: List<String>?,
+    ): HttpResponse<CookiePreferences>
+}

--- a/src/test/resources/examples/cookieParameters/controllers/spring/Controllers.kt
+++ b/src/test/resources/examples/cookieParameters/controllers/spring/Controllers.kt
@@ -1,0 +1,44 @@
+package examples.cookieParameters.controllers
+
+import examples.cookieParameters.models.CookiePreferences
+import examples.cookieParameters.models.DisplayMode
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.validation.`annotation`.Validated
+import org.springframework.web.bind.`annotation`.CookieValue
+import org.springframework.web.bind.`annotation`.PathVariable
+import org.springframework.web.bind.`annotation`.RequestMapping
+import org.springframework.web.bind.`annotation`.RequestMethod
+import javax.validation.Valid
+import kotlin.String
+import kotlin.collections.List
+
+@Controller
+@Validated
+@RequestMapping("")
+public interface CookiesController {
+    /**
+     *
+     *
+     * @param id
+     * @param sessionId
+     * @param displayMode
+     * @param features
+     * @param locale
+     * @param scopes
+     */
+    @RequestMapping(
+        value = ["/cookies/{id}"],
+        produces = ["application/json"],
+        method = [RequestMethod.GET],
+    )
+    public fun getCookiePreferences(
+        @PathVariable(value = "id", required = true) id: String,
+        @CookieValue(value = "sessionId", required = true) sessionId: String,
+        @CookieValue(value = "displayMode", required = true) displayMode: DisplayMode,
+        @Valid @CookieValue(value = "features", required = true) features: List<String>,
+        @CookieValue(value = "locale", required = false) locale: String?,
+        @Valid @CookieValue(value = "scopes", required = false) scopes: List<String>?,
+    ): ResponseEntity<CookiePreferences>
+}

--- a/src/test/resources/examples/cookieParameters/models/ClientModels.kt
+++ b/src/test/resources/examples/cookieParameters/models/ClientModels.kt
@@ -1,0 +1,31 @@
+package examples.cookieParameters.models
+
+import com.fasterxml.jackson.`annotation`.JsonProperty
+import com.fasterxml.jackson.`annotation`.JsonValue
+import jakarta.validation.constraints.NotNull
+import kotlin.String
+import kotlin.collections.Map
+
+public data class CookiePreferences(
+    @param:JsonProperty("locale")
+    @get:JsonProperty("locale")
+    @get:NotNull
+    public val locale: String,
+)
+
+public enum class DisplayMode(
+    @JsonValue
+    public val `value`: String,
+) {
+    COMPACT("compact"),
+    DETAILED("detailed"),
+    ;
+
+    override fun toString(): String = value
+
+    public companion object {
+        private val mapping: Map<String, DisplayMode> = entries.associateBy(DisplayMode::value)
+
+        public fun fromValue(`value`: String): DisplayMode? = mapping[value]
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds support for OpenAPI cookie parameters across Fabrikt's existing client and controller targets.

It:

- adds cookies to the shared request-parameter representation;
- generates native cookie bindings for Spring, Micronaut and Ktor controllers;
- supports cookie serialization in OkHttp, OpenFeign, Spring HTTP Interface and Ktor clients;
- correctly handles required and optional cookies;
- supports scalar values, enums and one-dimensional arrays;
- rejects complex object and map cookies explicitly instead of generating unsafe `toString()` serialization;
- keeps generated output unchanged for specifications without cookie parameters.

OpenFeign uses a generated wrapper to construct a single Cookie header. This avoids emitting empty cookies for nullable parameters and preserves the requested `explode` behavior.

## Verification

- Added focused golden-file coverage for all affected generators.
- Verified generated clients compile.
- Verified cookie serialization against real HTTP requests for OkHttp, OpenFeign, Spring HTTP Interface and Ktor.
- Verified the larger OpenAPI 3.0 and 3.1 specifications containing an optional cookie parameter generate successfully.
- Ran the complete build successfully: 126 tasks completed.
- Confirmed that no existing golden examples changed.

Fixes #185