### PR TITLE
Resolve source schema references within OpenAPI documents

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParser.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParser.kt
@@ -21,7 +21,7 @@ internal object OpenApiDocumentParser {
         jsonLoader: JsonLoader? = null,
     ): ParsedOpenApiDocument =
         try {
-            val source = SourceOpenApiDocumentParser.parse(input)
+            val source = SourceOpenApiDocumentParser.parse(input, baseUri)
             val kaizenInput = source.root.deepCopy<JsonNode>()
             OpenApi31Downgrader.downgradeIncompatibleElements(kaizenInput)
             OpenApiInputCleaner.cleanEmptyTypes(kaizenInput)

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiVersion.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/OpenApiVersion.kt
@@ -6,6 +6,11 @@ internal data class OpenApiVersion(
     val minor: Int,
     val patch: Int?,
 ) {
+    fun isAtLeast(
+        major: Int,
+        minor: Int,
+    ): Boolean = this.major > major || this.major == major && this.minor >= minor
+
     companion object {
         private val versionPattern = Regex("""^(\d+)\.(\d+)(?:\.(\d+))?(?:[-+].*)?$""")
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
@@ -2,31 +2,46 @@ package com.cjbooms.fabrikt.parser
 
 import com.cjbooms.fabrikt.util.YamlObjectMapper
 import com.fasterxml.jackson.databind.JsonNode
+import java.net.URI
+import java.nio.file.Paths
 
 internal data class SourceOpenApiDocument(
     val content: String,
     val root: JsonNode,
+    val baseUri: URI,
     val version: OpenApiVersion?,
     val componentSchemas: Map<String, SourceSchema>,
     val schemaEntryPoints: Map<String, SourceSchema>,
     val schemasByLocation: Map<String, SourceSchema>,
+    val schemaReferenceResolutions: Map<String, SourceSchemaReferenceResolution>,
 )
 
 internal object SourceOpenApiDocumentParser {
-    fun parse(input: String): SourceOpenApiDocument {
+    fun parse(
+        input: String,
+        baseUri: URI = Paths.get("").toAbsolutePath().toUri(),
+    ): SourceOpenApiDocument {
         val root = YamlObjectMapper.instance.readTree(input)
         val version = OpenApiVersion.parse(root["openapi"]?.asText())
         val schemaEntryPoints =
             SourceSchemaEntryPointCollector
                 .collect(root, version)
                 .mapValues { (location, node) -> readSchema(node, location, version) }
+        val schemasByLocation = indexSchemas(schemaEntryPoints.values)
         return SourceOpenApiDocument(
             content = input,
             root = root,
+            baseUri = baseUri,
             version = version,
             componentSchemas = readComponentSchemas(root, schemaEntryPoints),
             schemaEntryPoints = schemaEntryPoints,
-            schemasByLocation = indexSchemas(schemaEntryPoints.values),
+            schemasByLocation = schemasByLocation,
+            schemaReferenceResolutions =
+                SourceSchemaReferenceResolver.resolve(
+                    baseUri = baseUri,
+                    version = version,
+                    schemaEntryPoints = schemaEntryPoints.values,
+                ),
         )
     }
 
@@ -68,6 +83,8 @@ internal object SourceOpenApiDocumentParser {
             SourceObjectSchema(
                 location = location,
                 node = node,
+                identifier = node["\$id"]?.takeIf(JsonNode::isTextual)?.textValue(),
+                anchor = node["\$anchor"]?.takeIf(JsonNode::isTextual)?.textValue(),
                 types = readTypes(node, version),
                 reference = node["\$ref"]?.takeIf(JsonNode::isTextual)?.textValue(),
                 definitions = readNamedSchemas(node["\$defs"], "$location/\$defs", version),

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
@@ -16,6 +16,8 @@ internal data class SourceBooleanSchema(
 internal data class SourceObjectSchema(
     override val location: String,
     override val node: JsonNode,
+    val identifier: String?,
+    val anchor: String?,
     val types: Set<SourceSchemaType>,
     val reference: String?,
     val definitions: Map<String, SourceSchema>,

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaEntryPointCollector.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaEntryPointCollector.kt
@@ -12,8 +12,8 @@ internal object SourceSchemaEntryPointCollector {
         version: OpenApiVersion?,
     ) {
         private val entryPoints = linkedMapOf<String, JsonNode>()
-        private val supportsOpenApi31 = version.isAtLeast(3, 1)
-        private val supportsOpenApi32 = version.isAtLeast(3, 2)
+        private val supportsOpenApi31 = version?.isAtLeast(3, 1) == true
+        private val supportsOpenApi32 = version?.isAtLeast(3, 2) == true
 
         fun collect(root: JsonNode): Map<String, JsonNode> {
             collectComponents(root["components"], "#/components")
@@ -212,11 +212,6 @@ internal object SourceSchemaEntryPointCollector {
         }
 
         private fun JsonNode?.isInlineObject(): Boolean = this?.isObject == true && this["\$ref"]?.isTextual != true
-
-        private fun OpenApiVersion?.isAtLeast(
-            major: Int,
-            minor: Int,
-        ): Boolean = this != null && (this.major > major || this.major == major && this.minor >= minor)
 
         private fun String.isSpecificationExtension(): Boolean = startsWith("x-", ignoreCase = true)
 

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaReferenceResolution.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaReferenceResolution.kt
@@ -1,0 +1,27 @@
+package com.cjbooms.fabrikt.parser
+
+import java.net.URI
+
+internal sealed interface SourceSchemaReferenceResolution {
+    val value: String
+
+    data class Resolved(
+        override val value: String,
+        val uri: URI,
+        val target: SourceSchema,
+    ) : SourceSchemaReferenceResolution
+
+    data class Missing(
+        override val value: String,
+        val uri: URI,
+    ) : SourceSchemaReferenceResolution
+
+    data class External(
+        override val value: String,
+        val uri: URI,
+    ) : SourceSchemaReferenceResolution
+
+    data class Invalid(
+        override val value: String,
+    ) : SourceSchemaReferenceResolution
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaReferenceResolver.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaReferenceResolver.kt
@@ -1,0 +1,121 @@
+package com.cjbooms.fabrikt.parser
+
+import java.net.URI
+
+internal object SourceSchemaReferenceResolver {
+    fun resolve(
+        baseUri: URI,
+        version: OpenApiVersion?,
+        schemaEntryPoints: Collection<SourceSchema>,
+    ): Map<String, SourceSchemaReferenceResolution> {
+        val index = ReferenceIndex(baseUri.withoutFragment().toAsciiUri(), version?.isAtLeast(3, 1) == true)
+        schemaEntryPoints.forEach(index::index)
+        return index.resolveReferences()
+    }
+
+    private class ReferenceIndex(
+        private val documentUri: URI,
+        private val supportsSchemaResources: Boolean,
+    ) {
+        private val schemasByUri = linkedMapOf<URI, SourceSchema>()
+        private val baseUrisByLocation = linkedMapOf<String, URI>()
+        private val schemasByLocation = linkedMapOf<String, SourceSchema>()
+        private val resourceUris = linkedSetOf(documentUri)
+
+        fun index(schema: SourceSchema) {
+            index(schema, Scope(documentUri, documentUri, "#"))
+        }
+
+        fun resolveReferences(): Map<String, SourceSchemaReferenceResolution> =
+            schemasByLocation.values
+                .asSequence()
+                .filterIsInstance<SourceObjectSchema>()
+                .mapNotNull { schema ->
+                    schema.reference?.let { value -> schema.location to resolve(schema, value) }
+                }.toMap(linkedMapOf())
+
+        private fun index(
+            schema: SourceSchema,
+            inheritedScope: Scope,
+        ) {
+            val scope = schema.scope(inheritedScope)
+            schemasByLocation.putIfAbsent(schema.location, schema)
+            baseUrisByLocation.putIfAbsent(schema.location, scope.baseUri)
+            schemasByUri.putIfAbsent(documentUri.withFragment(schema.location.removePrefix("#")), schema)
+            schemasByUri.putIfAbsent(scope.uriFor(schema.location), schema)
+
+            if (schema is SourceObjectSchema && supportsSchemaResources) {
+                schema.anchor
+                    ?.takeIf(ANCHOR_PATTERN::matches)
+                    ?.let { anchor -> schemasByUri.putIfAbsent(scope.resourceUri.withFragment(anchor), schema) }
+            }
+
+            schema.childSchemas().forEach { child -> index(child, scope) }
+        }
+
+        private fun SourceSchema.scope(inherited: Scope): Scope {
+            if (this !is SourceObjectSchema || !supportsSchemaResources) return inherited
+            val resolvedIdentifier = identifier?.resolveAgainst(inherited.baseUri) ?: return inherited
+            if (!resolvedIdentifier.hasEmptyFragment()) return inherited
+
+            val resourceUri = resolvedIdentifier.withoutFragment()
+            resourceUris.add(resourceUri)
+            return Scope(resourceUri, resourceUri, location)
+        }
+
+        private fun resolve(
+            schema: SourceObjectSchema,
+            value: String,
+        ): SourceSchemaReferenceResolution {
+            val resolvedUri =
+                value.resolveAgainst(baseUrisByLocation.getValue(schema.location))
+                    ?: return SourceSchemaReferenceResolution.Invalid(value)
+            val canonicalUri = resolvedUri.withoutEmptyFragment()
+            val target = schemasByUri[canonicalUri]
+            if (target != null) return SourceSchemaReferenceResolution.Resolved(value, canonicalUri, target)
+
+            return if (canonicalUri.withoutFragment() in resourceUris) {
+                SourceSchemaReferenceResolution.Missing(value, canonicalUri)
+            } else {
+                SourceSchemaReferenceResolution.External(value, canonicalUri)
+            }
+        }
+    }
+
+    private data class Scope(
+        val baseUri: URI,
+        val resourceUri: URI,
+        val resourceRootLocation: String,
+    ) {
+        fun uriFor(location: String): URI {
+            if (location == resourceRootLocation) return resourceUri
+            val pointer =
+                if (resourceRootLocation == "#") {
+                    location.removePrefix("#")
+                } else {
+                    location.removePrefix(resourceRootLocation)
+                }
+            return resourceUri.withFragment(pointer)
+        }
+    }
+
+    private fun String.resolveAgainst(baseUri: URI): URI? {
+        if (isEmpty()) return baseUri
+        return runCatching { baseUri.resolve(URI(this)).normalize().toAsciiUri() }.getOrNull()
+    }
+
+    private fun URI.hasEmptyFragment(): Boolean = rawFragment.isNullOrEmpty()
+
+    private fun URI.withoutEmptyFragment(): URI = if (rawFragment == "") withoutFragment() else this
+
+    private fun URI.withoutFragment(): URI = rawFragment?.let { URI(toString().substringBeforeLast('#')) } ?: this
+
+    private fun URI.withFragment(fragment: String): URI {
+        val encodedFragment = URI(null, null, null, fragment).rawFragment
+        return URI("${withoutFragment()}#$encodedFragment").toAsciiUri()
+    }
+
+    private fun URI.toAsciiUri(): URI = URI(toASCIIString())
+
+    private val ANCHOR_PATTERN = Regex("^[A-Za-z_][-A-Za-z0-9._]*$")
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParserTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/OpenApiDocumentParserTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import java.net.URI
 
 class OpenApiDocumentParserTest {
     @Test
@@ -57,5 +58,34 @@ class OpenApiDocumentParserTest {
 
         assertThat(version)
             .isEqualTo(OpenApiVersion(value, major, minor, patch))
+    }
+
+    @Test
+    fun `uses the supplied base URI for source reference resolution`() {
+        val input =
+            """
+            openapi: 3.1.0
+            info:
+              title: Test
+              version: "1.0"
+            paths: {}
+            components:
+              schemas:
+                Name:
+                  type: string
+                Alias:
+                  ${'$'}ref: '#/components/schemas/Name'
+            """.trimIndent()
+        val baseUri = URI("https://example.test/specs%20with%20spaces/openapi.yaml")
+
+        val source = OpenApiDocumentParser.parse(input, baseUri).source
+        val resolution =
+            source.schemaReferenceResolutions.getValue("#/components/schemas/Alias") as
+                SourceSchemaReferenceResolution.Resolved
+
+        assertThat(source.baseUri).isEqualTo(baseUri)
+        assertThat(resolution.uri)
+            .isEqualTo(URI("https://example.test/specs%20with%20spaces/openapi.yaml#/components/schemas/Name"))
+        assertThat(resolution.target).isSameAs(source.componentSchemas.getValue("Name"))
     }
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaReferenceResolverTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaReferenceResolverTest.kt
@@ -1,0 +1,164 @@
+package com.cjbooms.fabrikt.parser
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.net.URI
+
+class SourceSchemaReferenceResolverTest {
+    @ParameterizedTest
+    @ValueSource(strings = ["3.0.4", "3.1.2", "3.2.0"])
+    fun `resolves local JSON Pointer schema references without following them`(version: String) {
+        val document =
+            parse(
+                version,
+                """
+                components:
+                  schemas:
+                    First:
+                      ${'$'}ref: '#/components/schemas/Second'
+                    Second:
+                      ${'$'}ref: '#/components/schemas/First'
+                    Target/with~escape and café:
+                      type: string
+                    Escaped:
+                      ${'$'}ref: '#/components/schemas/Target~1with~0escape%20and%20caf%C3%A9'
+                """,
+            )
+
+        val firstReference = document.resolvedReference("#/components/schemas/First")
+        val secondReference = document.resolvedReference("#/components/schemas/Second")
+        val escapedReference = document.resolvedReference("#/components/schemas/Escaped")
+
+        assertThat(firstReference.target).isSameAs(document.componentSchemas.getValue("Second"))
+        assertThat(secondReference.target).isSameAs(document.componentSchemas.getValue("First"))
+        assertThat(escapedReference.value).isEqualTo("#/components/schemas/Target~1with~0escape%20and%20caf%C3%A9")
+        assertThat(escapedReference.uri)
+            .isEqualTo(URI("https://example.test/specs/openapi.yaml#/components/schemas/Target~1with~0escape%20and%20caf%C3%A9"))
+        assertThat(escapedReference.target)
+            .isSameAs(document.componentSchemas.getValue("Target/with~escape and café"))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["3.1.2", "3.2.0"])
+    fun `resolves schema resources anchors and references to boolean schemas`(version: String) {
+        val document =
+            parse(
+                version,
+                """
+                components:
+                  schemas:
+                    Root:
+                      ${'$'}id: schemas/root.json
+                      ${'$'}defs:
+                        Anchored:
+                          ${'$'}anchor: named
+                          type: string
+                        Boolean: false
+                        Embedded:
+                          ${'$'}id: embedded.json
+                          ${'$'}anchor: embedded
+                          type: object
+                      properties:
+                        self:
+                          ${'$'}ref: ''
+                        anchor:
+                          ${'$'}ref: '#named'
+                          description: Reference sibling
+                        boolean:
+                          ${'$'}ref: '#/${'$'}defs/Boolean'
+                        embeddedResource:
+                          ${'$'}ref: 'embedded.json'
+                        embeddedAnchor:
+                          ${'$'}ref: 'embedded.json#embedded'
+                """,
+            )
+        val root = document.componentSchemas.getValue("Root") as SourceObjectSchema
+        val anchored = root.definitions.getValue("Anchored") as SourceObjectSchema
+        val boolean = root.definitions.getValue("Boolean") as SourceBooleanSchema
+        val embedded = root.definitions.getValue("Embedded")
+        val anchorReference = document.resolvedReference("#/components/schemas/Root/properties/anchor")
+
+        assertThat(root.identifier).isEqualTo("schemas/root.json")
+        assertThat(anchored.anchor).isEqualTo("named")
+        assertThat(document.resolvedReference("#/components/schemas/Root/properties/self").target)
+            .isSameAs(root)
+        assertThat(anchorReference.uri).isEqualTo(URI("https://example.test/specs/schemas/root.json#named"))
+        assertThat(anchorReference.target).isSameAs(anchored)
+        assertThat((root.properties.getValue("anchor") as SourceObjectSchema).node["description"].textValue())
+            .isEqualTo("Reference sibling")
+        assertThat(document.resolvedReference("#/components/schemas/Root/properties/boolean").target)
+            .isSameAs(boolean)
+        assertThat(document.resolvedReference("#/components/schemas/Root/properties/embeddedResource").target)
+            .isSameAs(embedded)
+        assertThat(document.resolvedReference("#/components/schemas/Root/properties/embeddedAnchor").target)
+            .isSameAs(embedded)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["3.1.2", "3.2.0"])
+    fun `classifies missing external and invalid schema references`(version: String) {
+        val document =
+            parse(
+                version,
+                """
+                components:
+                  schemas:
+                    Root:
+                      ${'$'}id: schemas/root.json
+                      properties:
+                        missingPointer:
+                          ${'$'}ref: '#/${'$'}defs/Missing'
+                        missingAnchor:
+                          ${'$'}ref: '#missing'
+                        external:
+                          ${'$'}ref: '../external.yaml#/components/schemas/External'
+                        invalid:
+                          ${'$'}ref: 'http://[invalid'
+                """,
+            )
+
+        assertThat(document.reference("#/components/schemas/Root/properties/missingPointer"))
+            .isEqualTo(
+                SourceSchemaReferenceResolution.Missing(
+                    value = "#/${'$'}defs/Missing",
+                    uri = URI("https://example.test/specs/schemas/root.json#/${'$'}defs/Missing"),
+                ),
+            )
+        assertThat(document.reference("#/components/schemas/Root/properties/missingAnchor"))
+            .isInstanceOf(SourceSchemaReferenceResolution.Missing::class.java)
+        assertThat(document.reference("#/components/schemas/Root/properties/external"))
+            .isEqualTo(
+                SourceSchemaReferenceResolution.External(
+                    value = "../external.yaml#/components/schemas/External",
+                    uri = URI("https://example.test/specs/external.yaml#/components/schemas/External"),
+                ),
+            )
+        assertThat(document.reference("#/components/schemas/Root/properties/invalid"))
+            .isEqualTo(SourceSchemaReferenceResolution.Invalid("http://[invalid"))
+    }
+
+    private fun parse(
+        version: String,
+        body: String,
+    ): SourceOpenApiDocument {
+        val document =
+            """
+            openapi: $version
+            info:
+              title: Test
+              version: "1.0"
+            paths: {}
+            """.trimIndent() + "\n" + body.trimIndent()
+        return SourceOpenApiDocumentParser.parse(
+            document,
+            URI("https://example.test/specs/openapi.yaml"),
+        )
+    }
+
+    private fun SourceOpenApiDocument.reference(location: String): SourceSchemaReferenceResolution =
+        schemaReferenceResolutions.getValue(location)
+
+    private fun SourceOpenApiDocument.resolvedReference(location: String): SourceSchemaReferenceResolution.Resolved =
+        reference(location) as SourceSchemaReferenceResolution.Resolved
+}


### PR DESCRIPTION
Title: Resolve source schema references within OpenAPI documents

## Summary

Builds on #668 by adding reference resolution to the Fabrikt-owned source schema model.

- Preserves the document base URI during parsing.
- Resolves local JSON Pointer references for OpenAPI 3.0, 3.1, and 3.2 documents.
- Supports JSON Schema `$id` resources and `$anchor` references for OpenAPI 3.1 and 3.2.
- Resolves references to object and boolean schemas while preserving schema identity.
- Handles cyclic references without recursively following them.
- Distinguishes resolved, missing, external, and syntactically invalid references.
- Preserves escaped JSON Pointer tokens, URI encoding, and `$ref` siblings.

External documents are deliberately classified but not loaded yet. Cross-document resolution will be introduced separately so this change remains focused and reviewable.

The existing Kaizen-backed generation path is unchanged, and this PR does not alter generated output.

Part of #656.

## Verification

- Added focused tests for OpenAPI 3.0, 3.1, and 3.2 reference behaviour.
- Added coverage for cycles, escaped names, schema resources, anchors, boolean schemas, missing targets, external references, invalid URIs, and supplied base URIs.
- `./gradlew clean build`
- 126 Gradle tasks completed successfully, including all end-to-end projects.