### PR TITLE
docs: fix auth option markdown rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@ User-facing docs, CLI options, and feature lists live in README.md — reference
 - Build: `./gradlew clean build`
 - Test: `./gradlew test`
 - Single test class: `./gradlew :test --tests "com.cjbooms.fabrikt.generators.ModelGeneratorTest"`
-- CLI usage: `./gradlew printCodeGenUsage`
-- The README CLI options table is generated from `printCodeGenUsage` output — never hand-edit it. After changing any `@Parameter` description in `CodeGenArgs.kt`, regenerate the table section from fresh output and verify the diff contains only your change.
+- Regenerate README CLI usage: `./gradlew printCodeGenUsage`
+- After changing any `@Parameter` description in `CodeGenArgs.kt`, run `printCodeGenUsage` and replace the entire README CLI usage section with its fresh output. Never hand-edit individual table rows. Verify the diff contains only the intended change.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Usage: <main class> [options]
 | ------------------------------ | ------------------------------ |
 |   `--api-file`                 | This must be a valid Open API v3 spec. All code generation will be based off this input. Accepts either a local file path or a resolvable http(s) URL. |
 |   `--api-fragment`             | A partial Open API v3 fragment, to be combined with the primary API for code generation purposes. Accepts either a local file path or a resolvable http(s) URL. |
-|   `--auth`                     | Authorization header(s) sent when fetching a remote --api-file, --api-fragment, or remote $ref. Repeatable, format 'Name: value'. Value may contain ${ENV_VAR} placeholders, name an env var, or contain !cmd (at start or after whitespace) to run a shell command and substitute its trimmed stdout (e.g. --auth "Authorization: Bearer !generate-fresh-auth-token"). |
+|   `--auth`                     | Authorization header(s) sent when fetching a remote --api-file, --api-fragment, or remote `$ref`. Repeatable, format 'Name: value'. Value may contain `${ENV_VAR}` placeholders, name an env var, or contain !cmd (at start or after whitespace) to run a shell command and substitute its trimmed stdout (e.g. --auth "Authorization: Bearer !generate-fresh-auth-token"). |
 | * `--base-package`             | The base package which all code will be generated under. |
 |   `--external-ref-resolution`  | Specify to which degree referenced schemas from external files are included in model generation. Default: TARGETED |
 |                                | CHOOSE ONE OF: |

--- a/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenArgs.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/cli/CodeGenArgs.kt
@@ -78,7 +78,7 @@ class CodeGenArgs {
         names = ["--auth"],
         description =
             "Authorization header(s) sent when fetching a remote --api-file, --api-fragment, or " +
-                "remote \$ref. Repeatable, format 'Name: value'. Value may contain \${ENV_VAR} placeholders, " +
+                "remote `\$ref`. Repeatable, format 'Name: value'. Value may contain `\${ENV_VAR}` placeholders, " +
                 "name an env var, or contain !cmd (at start or after whitespace) to run a shell command and " +
                 "substitute its trimmed stdout (e.g. --auth \"Authorization: Bearer !generate-fresh-auth-token\").",
     )


### PR DESCRIPTION
Fixes `$ref` formatting in the README + updates agent instructions.