### PR TITLE
Resolve source schema references across documents

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceDocumentLoader.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceDocumentLoader.kt
@@ -1,0 +1,21 @@
+package com.cjbooms.fabrikt.parser
+
+import com.cjbooms.fabrikt.util.HttpFetch
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Paths
+
+internal fun interface SourceDocumentLoader {
+    fun load(documentUri: URI): String
+}
+
+internal class DefaultSourceDocumentLoader(
+    private val headers: List<Pair<String, String>> = emptyList(),
+) : SourceDocumentLoader {
+    override fun load(documentUri: URI): String =
+        when (documentUri.scheme?.lowercase()) {
+            "file" -> Files.readString(Paths.get(documentUri))
+            "http", "https" -> HttpFetch.fetch(documentUri, headers)
+            else -> throw IllegalArgumentException("Unsupported source document URI: $documentUri")
+        }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocument.kt
@@ -13,8 +13,11 @@ internal data class SourceOpenApiDocument(
     val componentSchemas: Map<String, SourceSchema>,
     val schemaEntryPoints: Map<String, SourceSchema>,
     val schemasByLocation: Map<String, SourceSchema>,
-    val schemaReferenceResolutions: Map<String, SourceSchemaReferenceResolution>,
-)
+    val schemaReferenceIndex: SourceSchemaReferenceIndex,
+) {
+    val schemaReferenceResolutions: Map<String, SourceSchemaReferenceResolution>
+        get() = schemaReferenceIndex.resolutionsByLocation
+}
 
 internal object SourceOpenApiDocumentParser {
     fun parse(
@@ -26,7 +29,7 @@ internal object SourceOpenApiDocumentParser {
         val schemaEntryPoints =
             SourceSchemaEntryPointCollector
                 .collect(root, version)
-                .mapValues { (location, node) -> readSchema(node, location, version) }
+                .mapValues { (location, node) -> SourceSchemaParser.parse(node, location, version) }
         val schemasByLocation = indexSchemas(schemaEntryPoints.values)
         return SourceOpenApiDocument(
             content = input,
@@ -36,8 +39,8 @@ internal object SourceOpenApiDocumentParser {
             componentSchemas = readComponentSchemas(root, schemaEntryPoints),
             schemaEntryPoints = schemaEntryPoints,
             schemasByLocation = schemasByLocation,
-            schemaReferenceResolutions =
-                SourceSchemaReferenceResolver.resolve(
+            schemaReferenceIndex =
+                SourceSchemaReferenceResolver.index(
                     baseUri = baseUri,
                     version = version,
                     schemaEntryPoints = schemaEntryPoints.values,
@@ -70,118 +73,6 @@ internal object SourceOpenApiDocumentParser {
     private fun SourceSchema.visitRecursively(visitor: (SourceSchema) -> Unit) {
         visitor(this)
         childSchemas().forEach { it.visitRecursively(visitor) }
-    }
-
-    private fun readSchema(
-        node: JsonNode,
-        location: String,
-        version: OpenApiVersion?,
-    ): SourceSchema =
-        if (node.isBoolean) {
-            SourceBooleanSchema(location, node, node.booleanValue())
-        } else {
-            SourceObjectSchema(
-                location = location,
-                node = node,
-                identifier = node["\$id"]?.takeIf(JsonNode::isTextual)?.textValue(),
-                anchor = node["\$anchor"]?.takeIf(JsonNode::isTextual)?.textValue(),
-                types = readTypes(node, version),
-                reference = node["\$ref"]?.takeIf(JsonNode::isTextual)?.textValue(),
-                definitions = readNamedSchemas(node["\$defs"], "$location/\$defs", version),
-                properties = readNamedSchemas(node["properties"], "$location/properties", version),
-                patternProperties =
-                    readNamedSchemas(
-                        node["patternProperties"],
-                        "$location/patternProperties",
-                        version,
-                    ),
-                dependentSchemas =
-                    readNamedSchemas(
-                        node["dependentSchemas"],
-                        "$location/dependentSchemas",
-                        version,
-                    ),
-                prefixItems = readSchemaList(node["prefixItems"], "$location/prefixItems", version),
-                items = readOptionalSchema(node["items"], "$location/items", version),
-                contains = readOptionalSchema(node["contains"], "$location/contains", version),
-                propertyNames = readOptionalSchema(node["propertyNames"], "$location/propertyNames", version),
-                ifSchema = readOptionalSchema(node["if"], "$location/if", version),
-                thenSchema = readOptionalSchema(node["then"], "$location/then", version),
-                elseSchema = readOptionalSchema(node["else"], "$location/else", version),
-                allOf = readSchemaList(node["allOf"], "$location/allOf", version),
-                anyOf = readSchemaList(node["anyOf"], "$location/anyOf", version),
-                oneOf = readSchemaList(node["oneOf"], "$location/oneOf", version),
-                not = readOptionalSchema(node["not"], "$location/not", version),
-                additionalProperties =
-                    readOptionalSchema(
-                        node["additionalProperties"],
-                        "$location/additionalProperties",
-                        version,
-                    ),
-                unevaluatedItems =
-                    readOptionalSchema(
-                        node["unevaluatedItems"],
-                        "$location/unevaluatedItems",
-                        version,
-                    ),
-                unevaluatedProperties =
-                    readOptionalSchema(
-                        node["unevaluatedProperties"],
-                        "$location/unevaluatedProperties",
-                        version,
-                    ),
-                contentSchema = readOptionalSchema(node["contentSchema"], "$location/contentSchema", version),
-            )
-        }
-
-    private fun readNamedSchemas(
-        node: JsonNode?,
-        location: String,
-        version: OpenApiVersion?,
-    ): Map<String, SourceSchema> {
-        if (node?.isObject != true) return emptyMap()
-
-        return node.properties().associate { (name, schema) ->
-            name to readSchema(schema, "$location/${name.toJsonPointerToken()}", version)
-        }
-    }
-
-    private fun readOptionalSchema(
-        node: JsonNode?,
-        location: String,
-        version: OpenApiVersion?,
-    ): SourceSchema? = node?.takeIf { it.isObject || it.isBoolean }?.let { readSchema(it, location, version) }
-
-    private fun readSchemaList(
-        node: JsonNode?,
-        location: String,
-        version: OpenApiVersion?,
-    ): List<SourceSchema> {
-        if (node?.isArray != true) return emptyList()
-
-        return node.mapIndexedNotNull { index, schema ->
-            schema.takeIf { it.isObject || it.isBoolean }?.let { readSchema(it, "$location/$index", version) }
-        }
-    }
-
-    private fun readTypes(
-        node: JsonNode,
-        version: OpenApiVersion?,
-    ): Set<SourceSchemaType> {
-        val typeNode = node["type"]
-        val declaredTypes =
-            when {
-                typeNode?.isTextual == true -> sequenceOf(typeNode.textValue())
-                typeNode?.isArray == true -> typeNode.asSequence().filter(JsonNode::isTextual).map(JsonNode::textValue)
-                else -> emptySequence()
-            }.map(SourceSchemaType::from)
-                .toCollection(linkedSetOf())
-
-        if (version?.major == 3 && version.minor == 0 && declaredTypes.isNotEmpty() && node["nullable"]?.asBoolean() == true) {
-            declaredTypes.add(SourceSchemaType.NULL)
-        }
-
-        return declaredTypes
     }
 
     private fun String.toJsonPointerToken(): String = replace("~", "~0").replace("/", "~1")

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocumentGraph.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocumentGraph.kt
@@ -1,0 +1,107 @@
+package com.cjbooms.fabrikt.parser
+
+import java.net.URI
+import java.util.ArrayDeque
+
+internal data class SourceSchemaReferenceLocation(
+    val documentUri: URI,
+    val schemaLocation: String,
+)
+
+internal data class SourceDocumentLoadFailure(
+    val documentUri: URI,
+    val exception: Exception,
+)
+
+internal data class SourceOpenApiDocumentGraph(
+    val rootDocument: SourceOpenApiDocument,
+    val documentsByUri: Map<URI, SourceSchemaDocument>,
+    val schemaReferenceResolutions: Map<SourceSchemaReferenceLocation, SourceSchemaReferenceResolution>,
+    val loadFailures: Map<URI, SourceDocumentLoadFailure>,
+)
+
+internal object SourceOpenApiDocumentGraphParser {
+    fun parse(
+        input: String,
+        documentUri: URI,
+        documentLoader: SourceDocumentLoader,
+    ): SourceOpenApiDocumentGraph {
+        val canonicalDocumentUri = documentUri.withoutFragment().normalize().toAsciiUri()
+        val rootDocument = SourceOpenApiDocumentParser.parse(input, canonicalDocumentUri)
+        val documents = linkedMapOf(canonicalDocumentUri to rootDocument.asSchemaDocument())
+        val loadFailures = linkedMapOf<URI, SourceDocumentLoadFailure>()
+        val pendingDocumentUris = ArrayDeque<URI>()
+        enqueueExternalDocuments(documents.values.single(), pendingDocumentUris)
+
+        while (pendingDocumentUris.isNotEmpty()) {
+            val externalDocumentUri = pendingDocumentUris.removeFirst()
+            if (externalDocumentUri in documents || externalDocumentUri in loadFailures) continue
+            if (documents.values.any { externalDocumentUri in it.schemaReferenceIndex.resourceUris }) continue
+
+            try {
+                val externalDocument =
+                    SourceSchemaDocumentParser.parse(
+                        documentLoader.load(externalDocumentUri),
+                        externalDocumentUri,
+                    )
+                documents[externalDocumentUri] = externalDocument
+                enqueueExternalDocuments(externalDocument, pendingDocumentUris)
+            } catch (exception: Exception) {
+                loadFailures[externalDocumentUri] = SourceDocumentLoadFailure(externalDocumentUri, exception)
+            }
+        }
+
+        return SourceOpenApiDocumentGraph(
+            rootDocument = rootDocument,
+            documentsByUri = documents.toMap(),
+            schemaReferenceResolutions = resolveAcrossDocuments(documents.values),
+            loadFailures = loadFailures.toMap(),
+        )
+    }
+
+    private fun enqueueExternalDocuments(
+        document: SourceSchemaDocument,
+        pendingDocumentUris: ArrayDeque<URI>,
+    ) {
+        document.schemaReferenceIndex.resolutionsByLocation.values
+            .filterIsInstance<SourceSchemaReferenceResolution.External>()
+            .map { it.uri.withoutFragment() }
+            .forEach(pendingDocumentUris::addLast)
+    }
+
+    private fun resolveAcrossDocuments(
+        documents: Collection<SourceSchemaDocument>,
+    ): Map<SourceSchemaReferenceLocation, SourceSchemaReferenceResolution> {
+        val schemasByUri = linkedMapOf<URI, SourceSchema>()
+        val resourceUris = linkedSetOf<URI>()
+        documents.forEach { document ->
+            document.schemaReferenceIndex.schemasByUri.forEach(schemasByUri::putIfAbsent)
+            resourceUris.addAll(document.schemaReferenceIndex.resourceUris)
+        }
+
+        return buildMap {
+            documents.forEach { document ->
+                document.schemaReferenceIndex.resolutionsByLocation.forEach { (location, resolution) ->
+                    put(
+                        SourceSchemaReferenceLocation(document.documentUri, location),
+                        resolution.resolveAgainst(schemasByUri, resourceUris),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun SourceSchemaReferenceResolution.resolveAgainst(
+        schemasByUri: Map<URI, SourceSchema>,
+        resourceUris: Set<URI>,
+    ): SourceSchemaReferenceResolution {
+        if (this !is SourceSchemaReferenceResolution.External) return this
+        val target = schemasByUri[uri]
+        if (target != null) return SourceSchemaReferenceResolution.Resolved(value, uri, target)
+        return if (uri.withoutFragment() in resourceUris) {
+            SourceSchemaReferenceResolution.Missing(value, uri)
+        } else {
+            this
+        }
+    }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaDocument.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaDocument.kt
@@ -1,0 +1,64 @@
+package com.cjbooms.fabrikt.parser
+
+import com.cjbooms.fabrikt.util.YamlObjectMapper
+import com.fasterxml.jackson.databind.JsonNode
+import java.net.URI
+
+internal data class SourceSchemaDocument(
+    val documentUri: URI,
+    val content: String,
+    val root: JsonNode,
+    val schemaEntryPoints: Map<String, SourceSchema>,
+    val schemasByLocation: Map<String, SourceSchema>,
+    val schemaReferenceIndex: SourceSchemaReferenceIndex,
+)
+
+internal fun SourceOpenApiDocument.asSchemaDocument(): SourceSchemaDocument =
+    SourceSchemaDocument(
+        documentUri = baseUri.withoutFragment().normalize().toAsciiUri(),
+        content = content,
+        root = root,
+        schemaEntryPoints = schemaEntryPoints,
+        schemasByLocation = schemasByLocation,
+        schemaReferenceIndex = schemaReferenceIndex,
+    )
+
+internal object SourceSchemaDocumentParser {
+    fun parse(
+        input: String,
+        documentUri: URI,
+    ): SourceSchemaDocument {
+        val canonicalDocumentUri = documentUri.withoutFragment().normalize().toAsciiUri()
+        val root = YamlObjectMapper.instance.readTree(input)
+        if (OpenApiVersion.parse(root["openapi"]?.asText()) != null && root["info"]?.isObject == true) {
+            return SourceOpenApiDocumentParser.parse(input, canonicalDocumentUri).asSchemaDocument()
+        }
+        require(root.isObject || root.isBoolean) { "External schema document must contain an object or boolean schema: $documentUri" }
+
+        val rootSchema = SourceSchemaParser.parse(root, "#", null)
+        val schemasByLocation = indexSchemas(rootSchema)
+        return SourceSchemaDocument(
+            documentUri = canonicalDocumentUri,
+            content = input,
+            root = root,
+            schemaEntryPoints = mapOf("#" to rootSchema),
+            schemasByLocation = schemasByLocation,
+            schemaReferenceIndex =
+                SourceSchemaReferenceResolver.index(
+                    baseUri = canonicalDocumentUri,
+                    version = null,
+                    schemaEntryPoints = listOf(rootSchema),
+                    supportsSchemaResources = true,
+                ),
+        )
+    }
+
+    private fun indexSchemas(rootSchema: SourceSchema): Map<String, SourceSchema> =
+        buildMap {
+            fun index(schema: SourceSchema) {
+                put(schema.location, schema)
+                schema.childSchemas().forEach(::index)
+            }
+            index(rootSchema)
+        }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaParser.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaParser.kt
@@ -1,0 +1,119 @@
+package com.cjbooms.fabrikt.parser
+
+import com.fasterxml.jackson.databind.JsonNode
+
+internal object SourceSchemaParser {
+    fun parse(
+        node: JsonNode,
+        location: String,
+        version: OpenApiVersion?,
+    ): SourceSchema =
+        if (node.isBoolean) {
+            SourceBooleanSchema(location, node, node.booleanValue())
+        } else {
+            SourceObjectSchema(
+                location = location,
+                node = node,
+                identifier = node["\$id"]?.takeIf(JsonNode::isTextual)?.textValue(),
+                anchor = node["\$anchor"]?.takeIf(JsonNode::isTextual)?.textValue(),
+                types = readTypes(node, version),
+                reference = node["\$ref"]?.takeIf(JsonNode::isTextual)?.textValue(),
+                definitions = readNamedSchemas(node["\$defs"], "$location/\$defs", version),
+                properties = readNamedSchemas(node["properties"], "$location/properties", version),
+                patternProperties =
+                    readNamedSchemas(
+                        node["patternProperties"],
+                        "$location/patternProperties",
+                        version,
+                    ),
+                dependentSchemas =
+                    readNamedSchemas(
+                        node["dependentSchemas"],
+                        "$location/dependentSchemas",
+                        version,
+                    ),
+                prefixItems = readSchemaList(node["prefixItems"], "$location/prefixItems", version),
+                items = readOptionalSchema(node["items"], "$location/items", version),
+                contains = readOptionalSchema(node["contains"], "$location/contains", version),
+                propertyNames = readOptionalSchema(node["propertyNames"], "$location/propertyNames", version),
+                ifSchema = readOptionalSchema(node["if"], "$location/if", version),
+                thenSchema = readOptionalSchema(node["then"], "$location/then", version),
+                elseSchema = readOptionalSchema(node["else"], "$location/else", version),
+                allOf = readSchemaList(node["allOf"], "$location/allOf", version),
+                anyOf = readSchemaList(node["anyOf"], "$location/anyOf", version),
+                oneOf = readSchemaList(node["oneOf"], "$location/oneOf", version),
+                not = readOptionalSchema(node["not"], "$location/not", version),
+                additionalProperties =
+                    readOptionalSchema(
+                        node["additionalProperties"],
+                        "$location/additionalProperties",
+                        version,
+                    ),
+                unevaluatedItems =
+                    readOptionalSchema(
+                        node["unevaluatedItems"],
+                        "$location/unevaluatedItems",
+                        version,
+                    ),
+                unevaluatedProperties =
+                    readOptionalSchema(
+                        node["unevaluatedProperties"],
+                        "$location/unevaluatedProperties",
+                        version,
+                    ),
+                contentSchema = readOptionalSchema(node["contentSchema"], "$location/contentSchema", version),
+            )
+        }
+
+    private fun readNamedSchemas(
+        node: JsonNode?,
+        location: String,
+        version: OpenApiVersion?,
+    ): Map<String, SourceSchema> {
+        if (node?.isObject != true) return emptyMap()
+
+        return node.properties().associate { (name, schema) ->
+            name to parse(schema, "$location/${name.toJsonPointerToken()}", version)
+        }
+    }
+
+    private fun readOptionalSchema(
+        node: JsonNode?,
+        location: String,
+        version: OpenApiVersion?,
+    ): SourceSchema? = node?.takeIf { it.isObject || it.isBoolean }?.let { parse(it, location, version) }
+
+    private fun readSchemaList(
+        node: JsonNode?,
+        location: String,
+        version: OpenApiVersion?,
+    ): List<SourceSchema> {
+        if (node?.isArray != true) return emptyList()
+
+        return node.mapIndexedNotNull { index, schema ->
+            schema.takeIf { it.isObject || it.isBoolean }?.let { parse(it, "$location/$index", version) }
+        }
+    }
+
+    private fun readTypes(
+        node: JsonNode,
+        version: OpenApiVersion?,
+    ): Set<SourceSchemaType> {
+        val typeNode = node["type"]
+        val declaredTypes =
+            when {
+                typeNode?.isTextual == true -> sequenceOf(typeNode.textValue())
+                typeNode?.isArray == true -> typeNode.asSequence().filter(JsonNode::isTextual).map(JsonNode::textValue)
+                else -> emptySequence()
+            }.map(SourceSchemaType::from)
+                .toCollection(linkedSetOf())
+
+        if (version?.major == 3 && version.minor == 0 && declaredTypes.isNotEmpty() && node["nullable"]?.asBoolean() == true) {
+            declaredTypes.add(SourceSchemaType.NULL)
+        }
+
+        return declaredTypes
+    }
+
+    private fun String.toJsonPointerToken(): String = replace("~", "~0").replace("/", "~1")
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaReferenceResolution.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaReferenceResolution.kt
@@ -25,3 +25,10 @@ internal sealed interface SourceSchemaReferenceResolution {
         override val value: String,
     ) : SourceSchemaReferenceResolution
 }
+
+internal data class SourceSchemaReferenceIndex(
+    val documentUri: URI,
+    val schemasByUri: Map<URI, SourceSchema>,
+    val resourceUris: Set<URI>,
+    val resolutionsByLocation: Map<String, SourceSchemaReferenceResolution>,
+)

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaReferenceResolver.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaReferenceResolver.kt
@@ -3,14 +3,15 @@ package com.cjbooms.fabrikt.parser
 import java.net.URI
 
 internal object SourceSchemaReferenceResolver {
-    fun resolve(
+    fun index(
         baseUri: URI,
         version: OpenApiVersion?,
         schemaEntryPoints: Collection<SourceSchema>,
-    ): Map<String, SourceSchemaReferenceResolution> {
-        val index = ReferenceIndex(baseUri.withoutFragment().toAsciiUri(), version?.isAtLeast(3, 1) == true)
+        supportsSchemaResources: Boolean = version?.isAtLeast(3, 1) == true,
+    ): SourceSchemaReferenceIndex {
+        val index = ReferenceIndex(baseUri.withoutFragment().toAsciiUri(), supportsSchemaResources)
         schemaEntryPoints.forEach(index::index)
-        return index.resolveReferences()
+        return index.build()
     }
 
     private class ReferenceIndex(
@@ -26,13 +27,19 @@ internal object SourceSchemaReferenceResolver {
             index(schema, Scope(documentUri, documentUri, "#"))
         }
 
-        fun resolveReferences(): Map<String, SourceSchemaReferenceResolution> =
-            schemasByLocation.values
-                .asSequence()
-                .filterIsInstance<SourceObjectSchema>()
-                .mapNotNull { schema ->
-                    schema.reference?.let { value -> schema.location to resolve(schema, value) }
-                }.toMap(linkedMapOf())
+        fun build(): SourceSchemaReferenceIndex =
+            SourceSchemaReferenceIndex(
+                documentUri = documentUri,
+                schemasByUri = schemasByUri.toMap(),
+                resourceUris = resourceUris.toSet(),
+                resolutionsByLocation =
+                    schemasByLocation.values
+                        .asSequence()
+                        .filterIsInstance<SourceObjectSchema>()
+                        .mapNotNull { schema ->
+                            schema.reference?.let { value -> schema.location to resolve(schema, value) }
+                        }.toMap(linkedMapOf()),
+            )
 
         private fun index(
             schema: SourceSchema,
@@ -99,23 +106,9 @@ internal object SourceSchemaReferenceResolver {
         }
     }
 
-    private fun String.resolveAgainst(baseUri: URI): URI? {
-        if (isEmpty()) return baseUri
-        return runCatching { baseUri.resolve(URI(this)).normalize().toAsciiUri() }.getOrNull()
-    }
-
     private fun URI.hasEmptyFragment(): Boolean = rawFragment.isNullOrEmpty()
 
     private fun URI.withoutEmptyFragment(): URI = if (rawFragment == "") withoutFragment() else this
-
-    private fun URI.withoutFragment(): URI = rawFragment?.let { URI(toString().substringBeforeLast('#')) } ?: this
-
-    private fun URI.withFragment(fragment: String): URI {
-        val encodedFragment = URI(null, null, null, fragment).rawFragment
-        return URI("${withoutFragment()}#$encodedFragment").toAsciiUri()
-    }
-
-    private fun URI.toAsciiUri(): URI = URI(toASCIIString())
 
     private val ANCHOR_PATTERN = Regex("^[A-Za-z_][-A-Za-z0-9._]*$")
 }

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceUriUtils.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceUriUtils.kt
@@ -1,0 +1,17 @@
+package com.cjbooms.fabrikt.parser
+
+import java.net.URI
+
+internal fun String.resolveAgainst(baseUri: URI): URI? {
+    if (isEmpty()) return baseUri
+    return runCatching { baseUri.resolve(URI(this)).normalize().toAsciiUri() }.getOrNull()
+}
+
+internal fun URI.withoutFragment(): URI = rawFragment?.let { URI(toString().substringBeforeLast('#')) } ?: this
+
+internal fun URI.withFragment(fragment: String): URI {
+    val encodedFragment = URI(null, null, null, fragment).rawFragment
+    return URI("${withoutFragment()}#$encodedFragment").toAsciiUri()
+}
+
+internal fun URI.toAsciiUri(): URI = URI(toASCIIString())

--- a/src/main/kotlin/com/cjbooms/fabrikt/util/ApiFileLoader.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/util/ApiFileLoader.kt
@@ -9,6 +9,7 @@ import java.nio.file.Paths
 data class LoadedApi(
     val content: String,
     val baseUri: URI,
+    val documentUri: URI,
 )
 
 /**
@@ -40,11 +41,11 @@ object ApiFileLoader {
             )
         }
         val baseUri = (path.parent ?: path).toUri()
-        return LoadedApi(path.toFile().readText(), baseUri)
+        return LoadedApi(path.toFile().readText(), baseUri, path.toUri())
     }
 
     private fun loadRemote(
         uri: URI,
         resolvedAuth: List<Pair<String, String>>,
-    ): LoadedApi = LoadedApi(HttpFetch.fetch(uri, resolvedAuth), uri.resolve("."))
+    ): LoadedApi = LoadedApi(HttpFetch.fetch(uri, resolvedAuth), uri.resolve("."), uri)
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceDocumentLoaderTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceDocumentLoaderTest.kt
@@ -1,0 +1,42 @@
+package com.cjbooms.fabrikt.parser
+
+import com.sun.net.httpserver.HttpServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.net.URI
+import java.nio.charset.StandardCharsets
+
+class SourceDocumentLoaderTest {
+    private lateinit var server: HttpServer
+
+    @BeforeEach
+    fun startServer() {
+        server = HttpServer.create(InetSocketAddress("localhost", 0), 0)
+        server.start()
+    }
+
+    @AfterEach
+    fun stopServer() {
+        server.stop(0)
+    }
+
+    @Test
+    fun `loads HTTP documents with configured headers`() {
+        var authorizationHeader: String? = null
+        server.createContext("/schema.yaml") { exchange ->
+            authorizationHeader = exchange.requestHeaders.getFirst("Authorization")
+            val body = "type: string".toByteArray(StandardCharsets.UTF_8)
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        val uri = URI("http://localhost:${server.address.port}/schema.yaml")
+
+        val content = DefaultSourceDocumentLoader(listOf("Authorization" to "Bearer token")).load(uri)
+
+        assertThat(content).isEqualTo("type: string")
+        assertThat(authorizationHeader).isEqualTo("Bearer token")
+    }
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocumentGraphParserTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceOpenApiDocumentGraphParserTest.kt
@@ -1,0 +1,240 @@
+package com.cjbooms.fabrikt.parser
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.IOException
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+
+class SourceOpenApiDocumentGraphParserTest {
+    @Test
+    fun `loads YAML and JSON schema documents recursively from files`(
+        @TempDir tempDir: Path,
+    ) {
+        val rootUri = tempDir.resolve("openapi.yaml").toUri()
+        val schemasUri = tempDir.resolve("schemas.yaml").toUri()
+        val addressUri = tempDir.resolve("address.json").toUri()
+        Files.writeString(
+            schemasUri.toPath(),
+            """
+            ${'$'}schema: https://json-schema.org/draft/2020-12/schema
+            ${'$'}defs:
+              User:
+                type: object
+                properties:
+                  address:
+                    ${'$'}ref: address.json
+            """.trimIndent(),
+        )
+        Files.writeString(
+            addressUri.toPath(),
+            """
+            {
+              "${'$'}schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {
+                "street": { "type": "string" }
+              }
+            }
+            """.trimIndent(),
+        )
+
+        val graph =
+            SourceOpenApiDocumentGraphParser.parse(
+                openApiWithSchemas(
+                    """
+                    User:
+                      ${'$'}ref: 'schemas.yaml#/${'$'}defs/User'
+                    """,
+                ),
+                rootUri,
+                DefaultSourceDocumentLoader(),
+            )
+        val userTarget =
+            graph.documentsByUri
+                .getValue(schemasUri)
+                .schemasByLocation
+                .getValue("#/${'$'}defs/User")
+        val addressTarget =
+            graph.documentsByUri
+                .getValue(addressUri)
+                .schemasByLocation
+                .getValue("#")
+
+        assertThat(graph.documentsByUri).containsOnlyKeys(rootUri, schemasUri, addressUri)
+        assertThat(graph.loadFailures).isEmpty()
+        assertThat(graph.resolvedReference(rootUri, "#/components/schemas/User").target)
+            .isSameAs(userTarget)
+        assertThat(graph.resolvedReference(schemasUri, "#/${'$'}defs/User/properties/address").target)
+            .isSameAs(addressTarget)
+    }
+
+    @Test
+    fun `caches documents and resolves cycles across files`() {
+        val rootUri = URI("https://example.test/root.yaml")
+        val firstUri = URI("https://example.test/first.yaml")
+        val secondUri = URI("https://example.test/second.yaml")
+        val documents =
+            mapOf(
+                firstUri to
+                    """
+                    ${'$'}schema: https://json-schema.org/draft/2020-12/schema
+                    ${'$'}ref: second.yaml
+                    """.trimIndent(),
+                secondUri to
+                    """
+                    ${'$'}schema: https://json-schema.org/draft/2020-12/schema
+                    ${'$'}ref: first.yaml
+                    """.trimIndent(),
+            )
+        val loadCounts = mutableMapOf<URI, Int>()
+        val loader =
+            SourceDocumentLoader { uri ->
+                loadCounts.merge(uri, 1, Int::plus)
+                documents.getValue(uri)
+            }
+
+        val graph =
+            SourceOpenApiDocumentGraphParser.parse(
+                openApiWithSchemas(
+                    """
+                    FirstUse:
+                      ${'$'}ref: first.yaml
+                    SecondUse:
+                      ${'$'}ref: first.yaml
+                    """,
+                ),
+                rootUri,
+                loader,
+            )
+        val firstTarget =
+            graph.documentsByUri
+                .getValue(firstUri)
+                .schemasByLocation
+                .getValue("#")
+        val secondTarget =
+            graph.documentsByUri
+                .getValue(secondUri)
+                .schemasByLocation
+                .getValue("#")
+
+        assertThat(loadCounts).containsExactlyInAnyOrderEntriesOf(mapOf(firstUri to 1, secondUri to 1))
+        assertThat(graph.loadFailures).isEmpty()
+        assertThat(graph.resolvedReference(rootUri, "#/components/schemas/FirstUse").target)
+            .isSameAs(firstTarget)
+        assertThat(graph.resolvedReference(firstUri, "#").target)
+            .isSameAs(secondTarget)
+        assertThat(graph.resolvedReference(secondUri, "#").target)
+            .isSameAs(firstTarget)
+    }
+
+    @Test
+    fun `loads schemas from an external OpenAPI document`() {
+        val rootUri = URI("https://example.test/root.yaml")
+        val externalUri = URI("https://example.test/external.yaml")
+        val loader =
+            SourceDocumentLoader { uri ->
+                assertThat(uri).isEqualTo(externalUri)
+                openApiWithSchemas(
+                    """
+                    External:
+                      type: string
+                    """,
+                )
+            }
+
+        val graph =
+            SourceOpenApiDocumentGraphParser.parse(
+                openApiWithSchemas(
+                    """
+                    Alias:
+                      ${'$'}ref: 'external.yaml#/components/schemas/External'
+                    """,
+                ),
+                rootUri,
+                loader,
+            )
+        val externalTarget =
+            graph.documentsByUri
+                .getValue(externalUri)
+                .schemasByLocation
+                .getValue("#/components/schemas/External")
+
+        assertThat(graph.resolvedReference(rootUri, "#/components/schemas/Alias").target)
+            .isSameAs(externalTarget)
+    }
+
+    @Test
+    fun `records load failures once and reports missing targets in loaded documents`() {
+        val rootUri = URI("https://example.test/root.yaml")
+        val loadedUri = URI("https://example.test/loaded.yaml")
+        val unavailableUri = URI("https://example.test/unavailable.yaml")
+        val loadCounts = mutableMapOf<URI, Int>()
+        val loader =
+            SourceDocumentLoader { uri ->
+                loadCounts.merge(uri, 1, Int::plus)
+                when (uri) {
+                    loadedUri -> "type: object"
+                    else -> throw IOException("Unavailable: $uri")
+                }
+            }
+
+        val graph =
+            SourceOpenApiDocumentGraphParser.parse(
+                openApiWithSchemas(
+                    """
+                    MissingTarget:
+                      ${'$'}ref: 'loaded.yaml#/${'$'}defs/Missing'
+                    UnavailableOnce:
+                      ${'$'}ref: unavailable.yaml
+                    UnavailableTwice:
+                      ${'$'}ref: unavailable.yaml
+                    """,
+                ),
+                rootUri,
+                loader,
+            )
+
+        assertThat(loadCounts).containsExactlyInAnyOrderEntriesOf(mapOf(loadedUri to 1, unavailableUri to 1))
+        assertThat(graph.reference(rootUri, "#/components/schemas/MissingTarget"))
+            .isInstanceOf(SourceSchemaReferenceResolution.Missing::class.java)
+        assertThat(graph.reference(rootUri, "#/components/schemas/UnavailableOnce"))
+            .isInstanceOf(SourceSchemaReferenceResolution.External::class.java)
+        assertThat(graph.reference(rootUri, "#/components/schemas/UnavailableTwice"))
+            .isInstanceOf(SourceSchemaReferenceResolution.External::class.java)
+        assertThat(graph.loadFailures.getValue(unavailableUri).exception)
+            .isInstanceOf(IOException::class.java)
+            .hasMessage("Unavailable: $unavailableUri")
+    }
+
+    private fun openApiWithSchemas(schemas: String): String {
+        val document =
+            """
+            openapi: 3.1.0
+            info:
+              title: Test
+              version: "1.0"
+            paths: {}
+            components:
+              schemas:
+            """.trimIndent()
+        return "$document\n${schemas.trimIndent().prependIndent("    ")}"
+    }
+
+    private fun SourceOpenApiDocumentGraph.reference(
+        documentUri: URI,
+        schemaLocation: String,
+    ): SourceSchemaReferenceResolution =
+        schemaReferenceResolutions.getValue(
+            SourceSchemaReferenceLocation(documentUri, schemaLocation),
+        )
+
+    private fun SourceOpenApiDocumentGraph.resolvedReference(
+        documentUri: URI,
+        schemaLocation: String,
+    ): SourceSchemaReferenceResolution.Resolved = reference(documentUri, schemaLocation) as SourceSchemaReferenceResolution.Resolved
+
+    private fun URI.toPath(): Path = Path.of(this)
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/util/ApiFileLoaderTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/util/ApiFileLoaderTest.kt
@@ -66,6 +66,7 @@ class ApiFileLoaderTest {
 
         assertThat(loaded.content).isEqualTo("openapi: 3.0.0")
         assertThat(loaded.baseUri.toString()).isEqualTo("${baseUrl()}/specs/")
+        assertThat(loaded.documentUri.toString()).isEqualTo("${baseUrl()}/specs/api.yaml")
     }
 
     @Test
@@ -88,6 +89,7 @@ class ApiFileLoaderTest {
 
         assertThat(loaded.content).isEqualTo("openapi: 3.0.0")
         assertThat(loaded.baseUri).isEqualTo(tempDir.toUri())
+        assertThat(loaded.documentUri).isEqualTo(file.toUri())
     }
 
     @Test


### PR DESCRIPTION
## Summary

Builds on #671 by extending the Fabrikt-owned source schema model with cross-document reference resolution.

- Loads referenced OpenAPI and JSON Schema documents from YAML and JSON sources.
- Resolves references recursively across local files and HTTP resources.
- Combines loaded documents into a URI-aware source document graph.
- Caches documents to avoid duplicate loading and preserve cycles across files.
- Forwards configured HTTP headers when loading remote documents.
- Records document loading failures without losing other resolution results.
- Preserves the root document URI so relative references can be resolved consistently.

The existing Kaizen-backed generation path remains unchanged, and this PR does not alter generated output.

Part of #656.

## Verification

- Added tests for recursive YAML and JSON document loading.
- Added coverage for cross-file cycles, caching, external OpenAPI documents, missing targets, load failures, and HTTP header forwarding.
- `./gradlew clean build`
- 126 Gradle tasks completed successfully in WSL, including all end-to-end projects.