### PR TITLE
Introduce generator-facing schema contracts

### DIFF
--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/GeneratorSchema.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/GeneratorSchema.kt
@@ -16,6 +16,7 @@ internal interface GeneratorObjectSchema : GeneratorSchema {
     val anchor: String?
     val types: Set<SourceSchemaType>
     val reference: String?
+    val canonicalReference: String
     val metadata: SourceSchemaMetadata
     val constraints: SourceSchemaConstraints
     val requiredProperties: Set<String>

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/GeneratorSchema.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/GeneratorSchema.kt
@@ -1,0 +1,43 @@
+package com.cjbooms.fabrikt.parser
+
+internal interface GeneratorSchema {
+    val location: String
+    val identity: GeneratorSchemaIdentity
+}
+
+internal class GeneratorSchemaIdentity
+
+internal interface GeneratorBooleanSchema : GeneratorSchema {
+    val allowsAnyValue: Boolean
+}
+
+internal interface GeneratorObjectSchema : GeneratorSchema {
+    val identifier: String?
+    val anchor: String?
+    val types: Set<SourceSchemaType>
+    val reference: String?
+    val metadata: SourceSchemaMetadata
+    val constraints: SourceSchemaConstraints
+    val requiredProperties: Set<String>
+    val dependentRequired: Map<String, Set<String>>
+    val discriminator: SourceSchemaDiscriminator?
+    val definitions: Map<String, GeneratorSchema>
+    val properties: Map<String, GeneratorSchema>
+    val patternProperties: Map<String, GeneratorSchema>
+    val dependentSchemas: Map<String, GeneratorSchema>
+    val prefixItems: List<GeneratorSchema>
+    val items: GeneratorSchema?
+    val contains: GeneratorSchema?
+    val propertyNames: GeneratorSchema?
+    val ifSchema: GeneratorSchema?
+    val thenSchema: GeneratorSchema?
+    val elseSchema: GeneratorSchema?
+    val allOf: List<GeneratorSchema>
+    val anyOf: List<GeneratorSchema>
+    val oneOf: List<GeneratorSchema>
+    val not: GeneratorSchema?
+    val additionalProperties: GeneratorSchema?
+    val unevaluatedItems: GeneratorSchema?
+    val unevaluatedProperties: GeneratorSchema?
+    val contentSchema: GeneratorSchema?
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/GeneratorSchemaTypeClassifier.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/GeneratorSchemaTypeClassifier.kt
@@ -1,0 +1,127 @@
+package com.cjbooms.fabrikt.parser
+
+import com.cjbooms.fabrikt.model.OasType
+
+internal sealed interface GeneratorSchemaTypeClassification {
+    data class Resolved(
+        val type: OasType,
+        val nullable: Boolean,
+    ) : GeneratorSchemaTypeClassification
+
+    data class Unsupported(
+        val reason: Reason,
+    ) : GeneratorSchemaTypeClassification
+
+    enum class Reason {
+        NEVER_SCHEMA,
+        MULTIPLE_NON_NULL_TYPES,
+        INCONSISTENT_COMPOSITION_TYPES,
+    }
+}
+
+internal object GeneratorSchemaTypeClassifier {
+    fun classify(schema: GeneratorSchema): GeneratorSchemaTypeClassification =
+        when (schema) {
+            is GeneratorBooleanSchema ->
+                if (schema.allowsAnyValue) {
+                    GeneratorSchemaTypeClassification.Resolved(OasType.Any, false)
+                } else {
+                    GeneratorSchemaTypeClassification.Unsupported(GeneratorSchemaTypeClassification.Reason.NEVER_SCHEMA)
+                }
+            is GeneratorObjectSchema -> classifyObjectSchema(schema)
+            else -> error("Unknown generator schema implementation: ${schema::class.qualifiedName}")
+        }
+
+    private fun classifyObjectSchema(schema: GeneratorObjectSchema): GeneratorSchemaTypeClassification {
+        val nullable = SourceSchemaType.NULL in schema.types
+        val nonNullTypes = schema.types - SourceSchemaType.NULL
+        if (nonNullTypes.size > 1) {
+            return GeneratorSchemaTypeClassification.Unsupported(
+                GeneratorSchemaTypeClassification.Reason.MULTIPLE_NON_NULL_TYPES,
+            )
+        }
+
+        val type = nonNullTypes.singleOrNull() ?: inferType(schema)
+        if (type == null && schema.hasInconsistentCompositionTypes()) {
+            return GeneratorSchemaTypeClassification.Unsupported(
+                GeneratorSchemaTypeClassification.Reason.INCONSISTENT_COMPOSITION_TYPES,
+            )
+        }
+
+        return GeneratorSchemaTypeClassification.Resolved(schema.toOasType(type), nullable)
+    }
+
+    private fun inferType(schema: GeneratorObjectSchema): SourceSchemaType? {
+        if (schema.properties.isNotEmpty() || schema.hasAdditionalProperties()) return SourceSchemaType.OBJECT
+        if (schema.items != null || schema.prefixItems.isNotEmpty()) return SourceSchemaType.ARRAY
+
+        return schema
+            .compositionSchemas()
+            .mapNotNull { (classify(it) as? GeneratorSchemaTypeClassification.Resolved)?.type?.type }
+            .distinct()
+            .singleOrNull()
+            ?.let(SourceSchemaType::from)
+    }
+
+    private fun GeneratorObjectSchema.toOasType(type: SourceSchemaType?): OasType =
+        when (type) {
+            SourceSchemaType.STRING -> classifyString()
+            SourceSchemaType.NUMBER ->
+                when (metadata.format?.lowercase()) {
+                    "float" -> OasType.Float
+                    "double" -> OasType.Double
+                    else -> OasType.Number
+                }
+            SourceSchemaType.INTEGER ->
+                when (metadata.format?.lowercase()) {
+                    "int32" -> OasType.Int32
+                    "int64" -> OasType.Int64
+                    else -> OasType.Integer
+                }
+            SourceSchemaType.BOOLEAN -> OasType.Boolean
+            SourceSchemaType.ARRAY -> if (constraints.uniqueItems) OasType.Set else OasType.Array
+            SourceSchemaType.OBJECT -> classifyObject()
+            SourceSchemaType.NULL, null -> OasType.Any
+            else -> OasType.Any
+        }
+
+    private fun GeneratorObjectSchema.classifyString(): OasType =
+        when {
+            metadata.enumValues.isNotEmpty() -> OasType.Enum
+            metadata.format.equals("date", ignoreCase = true) -> OasType.Date
+            metadata.format.equals("date-time", ignoreCase = true) -> OasType.DateTime
+            metadata.format.equals("uuid", ignoreCase = true) -> OasType.Uuid
+            metadata.format.equals("uri", ignoreCase = true) -> OasType.Uri
+            metadata.format.equals("byte", ignoreCase = true) -> OasType.Base64String
+            metadata.format.equals("binary", ignoreCase = true) -> OasType.Binary
+            else -> OasType.Text
+        }
+
+    private fun GeneratorObjectSchema.classifyObject(): OasType =
+        when {
+            properties.isEmpty() && additionalProperties is GeneratorObjectSchema -> OasType.Map
+            properties.isEmpty() && additionalProperties == null && compositionSchemas().none() -> OasType.UntypedObject
+            else -> OasType.Object
+        }
+
+    private fun GeneratorObjectSchema.hasAdditionalProperties(): Boolean =
+        when (val value = additionalProperties) {
+            null -> false
+            is GeneratorBooleanSchema -> value.allowsAnyValue
+            else -> true
+        }
+
+    private fun GeneratorObjectSchema.hasInconsistentCompositionTypes(): Boolean {
+        val schemas = compositionSchemas().toList()
+        if (schemas.isEmpty()) return false
+        val types = schemas.mapNotNull { (classify(it) as? GeneratorSchemaTypeClassification.Resolved)?.type?.type }.distinct()
+        return types.size > 1
+    }
+
+    private fun GeneratorObjectSchema.compositionSchemas(): Sequence<GeneratorSchema> =
+        sequence {
+            yieldAll(allOf)
+            yieldAll(anyOf)
+            yieldAll(oneOf)
+        }
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/LegacyGeneratorSchemaAdapter.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/LegacyGeneratorSchemaAdapter.kt
@@ -1,0 +1,118 @@
+package com.cjbooms.fabrikt.parser
+
+import com.cjbooms.fabrikt.util.YamlUtils
+import com.fasterxml.jackson.databind.JsonNode
+import com.reprezen.jsonoverlay.Overlay
+import com.reprezen.kaizen.oasparser.model3.Schema
+import java.math.BigDecimal
+import java.util.IdentityHashMap
+
+internal class LegacyGeneratorSchemaAdapter {
+    private val schemas = IdentityHashMap<Schema, LegacyObjectSchema>()
+
+    fun adapt(schema: Schema): GeneratorObjectSchema = schemas.getOrPut(schema) { LegacyObjectSchema(schema) }
+
+    private inner class LegacyObjectSchema(
+        private val schema: Schema,
+    ) : GeneratorObjectSchema {
+        override val location: String = Overlay.of(schema).pathFromRoot
+        override val identity = GeneratorSchemaIdentity()
+        override val identifier: String? = null
+        override val anchor: String? = null
+        override val types: Set<SourceSchemaType>
+            get() =
+                buildSet {
+                    schema.type?.let { add(SourceSchemaType.from(it)) }
+                    if (schema.isNullable) add(SourceSchemaType.NULL)
+                }
+        override val reference: String? = null
+        override val canonicalReference: String = Overlay.of(schema).jsonReference
+        override val metadata: SourceSchemaMetadata
+            get() =
+                SourceSchemaMetadata(
+                    title = schema.title,
+                    description = schema.description,
+                    format = schema.format,
+                    defaultValue = schema.default?.toJsonNode(),
+                    examples =
+                        schema.example
+                            ?.toJsonNode()
+                            ?.let(::listOf)
+                            .orEmpty(),
+                    enumValues = schema.enums.map { it.toJsonNode() },
+                    constValue = null,
+                    readOnly = schema.isReadOnly,
+                    writeOnly = schema.isWriteOnly,
+                    deprecated = schema.isDeprecated,
+                    contentEncoding = null,
+                    contentMediaType = null,
+                    extensions = schema.extensions.mapValues { (_, value) -> value.toJsonNode() },
+                )
+        override val constraints: SourceSchemaConstraints
+            get() =
+                SourceSchemaConstraints(
+                    multipleOf = schema.multipleOf?.toBigDecimal(),
+                    minimum = schema.minimum?.toBigDecimal()?.let { SourceSchemaBound(it, schema.isExclusiveMinimum) },
+                    maximum = schema.maximum?.toBigDecimal()?.let { SourceSchemaBound(it, schema.isExclusiveMaximum) },
+                    minLength = schema.minLength,
+                    maxLength = schema.maxLength,
+                    pattern = schema.pattern,
+                    minItems = schema.minItems,
+                    maxItems = schema.maxItems,
+                    uniqueItems = schema.isUniqueItems,
+                    minContains = null,
+                    maxContains = null,
+                    minProperties = schema.minProperties,
+                    maxProperties = schema.maxProperties,
+                )
+        override val requiredProperties: Set<String>
+            get() = schema.requiredFields.toCollection(linkedSetOf())
+        override val dependentRequired: Map<String, Set<String>> = emptyMap()
+        override val discriminator: SourceSchemaDiscriminator?
+            get() =
+                schema.discriminator?.propertyName?.let { propertyName ->
+                    SourceSchemaDiscriminator(propertyName, schema.discriminator.mappings.orEmpty())
+                }
+        override val definitions: Map<String, GeneratorSchema> = emptyMap()
+        override val properties: Map<String, GeneratorSchema>
+            get() = schema.properties.mapValues { (_, child) -> adapt(child) }
+        override val patternProperties: Map<String, GeneratorSchema> = emptyMap()
+        override val dependentSchemas: Map<String, GeneratorSchema> = emptyMap()
+        override val prefixItems: List<GeneratorSchema> = emptyList()
+        override val items: GeneratorSchema?
+            get() = schema.itemsSchema.takeIfPresent()?.let(::adapt)
+        override val contains: GeneratorSchema? = null
+        override val propertyNames: GeneratorSchema? = null
+        override val ifSchema: GeneratorSchema? = null
+        override val thenSchema: GeneratorSchema? = null
+        override val elseSchema: GeneratorSchema? = null
+        override val allOf: List<GeneratorSchema>
+            get() = schema.allOfSchemas.map(::adapt)
+        override val anyOf: List<GeneratorSchema>
+            get() = schema.anyOfSchemas.map(::adapt)
+        override val oneOf: List<GeneratorSchema>
+            get() = schema.oneOfSchemas.map(::adapt)
+        override val not: GeneratorSchema?
+            get() = schema.notSchema.takeIfPresent()?.let(::adapt)
+        override val additionalProperties: GeneratorSchema?
+            get() =
+                schema.additionalProperties?.let(::LegacyBooleanSchema)
+                    ?: schema.additionalPropertiesSchema.takeIfPresent()?.let(::adapt)
+        override val unevaluatedItems: GeneratorSchema? = null
+        override val unevaluatedProperties: GeneratorSchema? = null
+        override val contentSchema: GeneratorSchema? = null
+    }
+
+    private class LegacyBooleanSchema(
+        override val allowsAnyValue: Boolean,
+    ) : GeneratorBooleanSchema {
+        override val location: String = ""
+        override val identity = GeneratorSchemaIdentity()
+    }
+
+    private fun Schema?.takeIfPresent(): Schema? = this?.takeIf { Overlay.of(it).isPresent }
+
+    private fun Number.toBigDecimal(): BigDecimal = this as? BigDecimal ?: BigDecimal(toString())
+
+    private fun Any?.toJsonNode(): JsonNode = YamlUtils.objectMapper.valueToTree(this)
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SchemaGenerationMode.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SchemaGenerationMode.kt
@@ -1,0 +1,34 @@
+package com.cjbooms.fabrikt.parser
+
+internal enum class SchemaGenerationMode {
+    LEGACY,
+    NATIVE,
+}
+
+internal class GeneratorSchemaDocument(
+    val version: OpenApiVersion?,
+    val componentSchemas: Map<String, GeneratorSchema>,
+    private val referencedSchemas: Map<GeneratorSchemaIdentity, GeneratorSchema>,
+) {
+    fun resolve(schema: GeneratorSchema): GeneratorSchema = referencedSchemas[schema.identity] ?: schema
+}
+
+internal fun ParsedOpenApiDocument.toGeneratorSchemaDocument(mode: SchemaGenerationMode): GeneratorSchemaDocument {
+    val (schemas, referencedSchemas) =
+        when (mode) {
+            SchemaGenerationMode.LEGACY -> {
+                val adapter = LegacyGeneratorSchemaAdapter()
+                kaizenModel.schemas.mapValues { (_, schema) -> adapter.adapt(schema) } to emptyMap()
+            }
+            SchemaGenerationMode.NATIVE ->
+                source.componentSchemas to
+                    source.schemaReferenceResolutions
+                        .mapNotNull { (location, resolution) ->
+                            val sourceSchema = source.schemasByLocation[location] ?: return@mapNotNull null
+                            val target = (resolution as? SourceSchemaReferenceResolution.Resolved)?.target ?: return@mapNotNull null
+                            sourceSchema.identity to target
+                        }.toMap()
+        }
+
+    return GeneratorSchemaDocument(version, schemas, referencedSchemas)
+}

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
@@ -1,6 +1,7 @@
 package com.cjbooms.fabrikt.parser
 
 import com.fasterxml.jackson.databind.JsonNode
+import java.math.BigDecimal
 
 internal sealed interface SourceSchema {
     val location: String
@@ -20,6 +21,11 @@ internal data class SourceObjectSchema(
     val anchor: String?,
     val types: Set<SourceSchemaType>,
     val reference: String?,
+    val metadata: SourceSchemaMetadata,
+    val constraints: SourceSchemaConstraints,
+    val requiredProperties: Set<String>,
+    val dependentRequired: Map<String, Set<String>>,
+    val discriminator: SourceSchemaDiscriminator?,
     val definitions: Map<String, SourceSchema>,
     val properties: Map<String, SourceSchema>,
     val patternProperties: Map<String, SourceSchema>,
@@ -40,6 +46,47 @@ internal data class SourceObjectSchema(
     val unevaluatedProperties: SourceSchema?,
     val contentSchema: SourceSchema?,
 ) : SourceSchema
+
+internal data class SourceSchemaMetadata(
+    val title: String?,
+    val description: String?,
+    val format: String?,
+    val defaultValue: JsonNode?,
+    val examples: List<JsonNode>,
+    val enumValues: List<JsonNode>,
+    val constValue: JsonNode?,
+    val readOnly: Boolean,
+    val writeOnly: Boolean,
+    val deprecated: Boolean,
+    val contentEncoding: String?,
+    val contentMediaType: String?,
+)
+
+internal data class SourceSchemaConstraints(
+    val multipleOf: BigDecimal?,
+    val minimum: SourceSchemaBound?,
+    val maximum: SourceSchemaBound?,
+    val minLength: Int?,
+    val maxLength: Int?,
+    val pattern: String?,
+    val minItems: Int?,
+    val maxItems: Int?,
+    val uniqueItems: Boolean,
+    val minContains: Int?,
+    val maxContains: Int?,
+    val minProperties: Int?,
+    val maxProperties: Int?,
+)
+
+internal data class SourceSchemaBound(
+    val value: BigDecimal,
+    val exclusive: Boolean,
+)
+
+internal data class SourceSchemaDiscriminator(
+    val propertyName: String,
+    val mapping: Map<String, String>,
+)
 
 internal fun SourceSchema.childSchemas(): Sequence<SourceSchema> =
     when (this) {

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
@@ -53,6 +53,7 @@ internal data class SourceObjectSchema(
 ) : SourceSchema,
     GeneratorObjectSchema {
     override val identity = GeneratorSchemaIdentity()
+    override val canonicalReference: String = location
 }
 
 internal data class SourceSchemaMetadata(
@@ -68,6 +69,7 @@ internal data class SourceSchemaMetadata(
     val deprecated: Boolean,
     val contentEncoding: String?,
     val contentMediaType: String?,
+    val extensions: Map<String, JsonNode>,
 )
 
 internal data class SourceSchemaConstraints(

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchema.kt
@@ -3,49 +3,57 @@ package com.cjbooms.fabrikt.parser
 import com.fasterxml.jackson.databind.JsonNode
 import java.math.BigDecimal
 
-internal sealed interface SourceSchema {
-    val location: String
+internal sealed interface SourceSchema : GeneratorSchema {
+    override val location: String
     val node: JsonNode
+
+    override val identity: GeneratorSchemaIdentity
 }
 
 internal data class SourceBooleanSchema(
     override val location: String,
     override val node: JsonNode,
-    val allowsAnyValue: Boolean,
-) : SourceSchema
+    override val allowsAnyValue: Boolean,
+) : SourceSchema,
+    GeneratorBooleanSchema {
+    override val identity = GeneratorSchemaIdentity()
+}
 
 internal data class SourceObjectSchema(
     override val location: String,
     override val node: JsonNode,
-    val identifier: String?,
-    val anchor: String?,
-    val types: Set<SourceSchemaType>,
-    val reference: String?,
-    val metadata: SourceSchemaMetadata,
-    val constraints: SourceSchemaConstraints,
-    val requiredProperties: Set<String>,
-    val dependentRequired: Map<String, Set<String>>,
-    val discriminator: SourceSchemaDiscriminator?,
-    val definitions: Map<String, SourceSchema>,
-    val properties: Map<String, SourceSchema>,
-    val patternProperties: Map<String, SourceSchema>,
-    val dependentSchemas: Map<String, SourceSchema>,
-    val prefixItems: List<SourceSchema>,
-    val items: SourceSchema?,
-    val contains: SourceSchema?,
-    val propertyNames: SourceSchema?,
-    val ifSchema: SourceSchema?,
-    val thenSchema: SourceSchema?,
-    val elseSchema: SourceSchema?,
-    val allOf: List<SourceSchema>,
-    val anyOf: List<SourceSchema>,
-    val oneOf: List<SourceSchema>,
-    val not: SourceSchema?,
-    val additionalProperties: SourceSchema?,
-    val unevaluatedItems: SourceSchema?,
-    val unevaluatedProperties: SourceSchema?,
-    val contentSchema: SourceSchema?,
-) : SourceSchema
+    override val identifier: String?,
+    override val anchor: String?,
+    override val types: Set<SourceSchemaType>,
+    override val reference: String?,
+    override val metadata: SourceSchemaMetadata,
+    override val constraints: SourceSchemaConstraints,
+    override val requiredProperties: Set<String>,
+    override val dependentRequired: Map<String, Set<String>>,
+    override val discriminator: SourceSchemaDiscriminator?,
+    override val definitions: Map<String, SourceSchema>,
+    override val properties: Map<String, SourceSchema>,
+    override val patternProperties: Map<String, SourceSchema>,
+    override val dependentSchemas: Map<String, SourceSchema>,
+    override val prefixItems: List<SourceSchema>,
+    override val items: SourceSchema?,
+    override val contains: SourceSchema?,
+    override val propertyNames: SourceSchema?,
+    override val ifSchema: SourceSchema?,
+    override val thenSchema: SourceSchema?,
+    override val elseSchema: SourceSchema?,
+    override val allOf: List<SourceSchema>,
+    override val anyOf: List<SourceSchema>,
+    override val oneOf: List<SourceSchema>,
+    override val not: SourceSchema?,
+    override val additionalProperties: SourceSchema?,
+    override val unevaluatedItems: SourceSchema?,
+    override val unevaluatedProperties: SourceSchema?,
+    override val contentSchema: SourceSchema?,
+) : SourceSchema,
+    GeneratorObjectSchema {
+    override val identity = GeneratorSchemaIdentity()
+}
 
 internal data class SourceSchemaMetadata(
     val title: String?,

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaParser.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaParser.kt
@@ -135,6 +135,10 @@ internal object SourceSchemaParser {
             deprecated = node["deprecated"]?.asBoolean() == true,
             contentEncoding = node.textValue("contentEncoding"),
             contentMediaType = node.textValue("contentMediaType"),
+            extensions =
+                node.properties().asSequence().filter { (name, _) -> name.startsWith("x-") }.associate { (name, value) ->
+                    name to value
+                },
         )
 
     private fun readExamples(node: JsonNode): List<JsonNode> =

--- a/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaParser.kt
+++ b/src/main/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaParser.kt
@@ -1,6 +1,7 @@
 package com.cjbooms.fabrikt.parser
 
 import com.fasterxml.jackson.databind.JsonNode
+import java.math.BigDecimal
 
 internal object SourceSchemaParser {
     fun parse(
@@ -18,6 +19,11 @@ internal object SourceSchemaParser {
                 anchor = node["\$anchor"]?.takeIf(JsonNode::isTextual)?.textValue(),
                 types = readTypes(node, version),
                 reference = node["\$ref"]?.takeIf(JsonNode::isTextual)?.textValue(),
+                metadata = readMetadata(node),
+                constraints = readConstraints(node, version),
+                requiredProperties = readStringSet(node["required"]),
+                dependentRequired = readDependentRequired(node["dependentRequired"]),
+                discriminator = readDiscriminator(node["discriminator"]),
                 definitions = readNamedSchemas(node["\$defs"], "$location/\$defs", version),
                 properties = readNamedSchemas(node["properties"], "$location/properties", version),
                 patternProperties =
@@ -114,6 +120,126 @@ internal object SourceSchemaParser {
 
         return declaredTypes
     }
+
+    private fun readMetadata(node: JsonNode): SourceSchemaMetadata =
+        SourceSchemaMetadata(
+            title = node.textValue("title"),
+            description = node.textValue("description"),
+            format = node.textValue("format"),
+            defaultValue = node["default"],
+            examples = readExamples(node),
+            enumValues = node["enum"]?.takeIf(JsonNode::isArray)?.toList().orEmpty(),
+            constValue = node["const"],
+            readOnly = node["readOnly"]?.asBoolean() == true,
+            writeOnly = node["writeOnly"]?.asBoolean() == true,
+            deprecated = node["deprecated"]?.asBoolean() == true,
+            contentEncoding = node.textValue("contentEncoding"),
+            contentMediaType = node.textValue("contentMediaType"),
+        )
+
+    private fun readExamples(node: JsonNode): List<JsonNode> =
+        node["examples"]?.takeIf(JsonNode::isArray)?.toList()
+            ?: node["example"]?.let(::listOf)
+            ?: emptyList()
+
+    private fun readConstraints(
+        node: JsonNode,
+        version: OpenApiVersion?,
+    ): SourceSchemaConstraints =
+        SourceSchemaConstraints(
+            multipleOf = node.decimalValue("multipleOf"),
+            minimum = readMinimum(node, version),
+            maximum = readMaximum(node, version),
+            minLength = node.intValue("minLength"),
+            maxLength = node.intValue("maxLength"),
+            pattern = node.textValue("pattern"),
+            minItems = node.intValue("minItems"),
+            maxItems = node.intValue("maxItems"),
+            uniqueItems = node["uniqueItems"]?.asBoolean() == true,
+            minContains = node.intValue("minContains"),
+            maxContains = node.intValue("maxContains"),
+            minProperties = node.intValue("minProperties"),
+            maxProperties = node.intValue("maxProperties"),
+        )
+
+    private fun readMinimum(
+        node: JsonNode,
+        version: OpenApiVersion?,
+    ): SourceSchemaBound? =
+        if (version.isOpenApi30()) {
+            node.decimalValue("minimum")?.let { SourceSchemaBound(it, node["exclusiveMinimum"]?.asBoolean() == true) }
+        } else {
+            strongestLowerBound(
+                node.decimalValue("minimum")?.let { SourceSchemaBound(it, false) },
+                node.decimalValue("exclusiveMinimum")?.let { SourceSchemaBound(it, true) },
+            )
+        }
+
+    private fun readMaximum(
+        node: JsonNode,
+        version: OpenApiVersion?,
+    ): SourceSchemaBound? =
+        if (version.isOpenApi30()) {
+            node.decimalValue("maximum")?.let { SourceSchemaBound(it, node["exclusiveMaximum"]?.asBoolean() == true) }
+        } else {
+            strongestUpperBound(
+                node.decimalValue("maximum")?.let { SourceSchemaBound(it, false) },
+                node.decimalValue("exclusiveMaximum")?.let { SourceSchemaBound(it, true) },
+            )
+        }
+
+    private fun strongestLowerBound(
+        inclusive: SourceSchemaBound?,
+        exclusive: SourceSchemaBound?,
+    ): SourceSchemaBound? =
+        listOfNotNull(inclusive, exclusive).maxWithOrNull(compareBy<SourceSchemaBound> { it.value }.thenBy { it.exclusive })
+
+    private fun strongestUpperBound(
+        inclusive: SourceSchemaBound?,
+        exclusive: SourceSchemaBound?,
+    ): SourceSchemaBound? =
+        listOfNotNull(inclusive, exclusive).minWithOrNull(compareBy<SourceSchemaBound> { it.value }.thenByDescending { it.exclusive })
+
+    private fun readDependentRequired(node: JsonNode?): Map<String, Set<String>> =
+        node
+            ?.takeIf(JsonNode::isObject)
+            ?.properties()
+            ?.asSequence()
+            ?.associate { (name, required) ->
+                name to readStringSet(required)
+            }.orEmpty()
+
+    private fun readDiscriminator(node: JsonNode?): SourceSchemaDiscriminator? {
+        val propertyName = node?.textValue("propertyName") ?: return null
+        val mapping =
+            node["mapping"]
+                ?.takeIf(JsonNode::isObject)
+                ?.properties()
+                ?.asSequence()
+                ?.mapNotNull { (name, target) ->
+                    target.takeIf(JsonNode::isTextual)?.textValue()?.let { name to it }
+                }?.toMap()
+                .orEmpty()
+        return SourceSchemaDiscriminator(propertyName, mapping)
+    }
+
+    private fun readStringSet(node: JsonNode?): Set<String> =
+        node
+            ?.takeIf(JsonNode::isArray)
+            ?.asSequence()
+            ?.filter(JsonNode::isTextual)
+            ?.map(JsonNode::textValue)
+            ?.toCollection(linkedSetOf())
+            ?: emptySet()
+
+    private fun JsonNode.textValue(fieldName: String): String? = get(fieldName)?.takeIf(JsonNode::isTextual)?.textValue()
+
+    private fun JsonNode.decimalValue(fieldName: String): BigDecimal? = get(fieldName)?.takeIf(JsonNode::isNumber)?.decimalValue()
+
+    private fun JsonNode.intValue(fieldName: String): Int? =
+        get(fieldName)?.takeIf(JsonNode::isIntegralNumber)?.takeIf(JsonNode::canConvertToInt)?.intValue()
+
+    private fun OpenApiVersion?.isOpenApi30(): Boolean = this?.major == 3 && minor == 0
 
     private fun String.toJsonPointerToken(): String = replace("~", "~0").replace("/", "~1")
 }

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/GeneratorSchemaTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/GeneratorSchemaTest.kt
@@ -1,0 +1,61 @@
+package com.cjbooms.fabrikt.parser
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GeneratorSchemaTest {
+    @Test
+    fun `source schemas expose the generator schema contract`() {
+        val schema: GeneratorSchema =
+            SourceOpenApiDocumentParser
+                .parse(
+                    """
+                    openapi: 3.1.2
+                    info:
+                      title: Test
+                      version: "1.0"
+                    paths: {}
+                    components:
+                      schemas:
+                        Root:
+                          type: object
+                          properties:
+                            value:
+                              type: string
+                          additionalProperties: false
+                    """.trimIndent(),
+                ).componentSchemas
+                .getValue("Root")
+
+        val objectSchema = schema as GeneratorObjectSchema
+        assertThat(objectSchema.types).containsExactly(SourceSchemaType.OBJECT)
+        assertThat(objectSchema.properties).containsOnlyKeys("value")
+        assertThat(objectSchema.properties.getValue("value").identity).isSameAs(
+            objectSchema.properties.getValue("value").identity,
+        )
+        assertThat((objectSchema.additionalProperties as GeneratorBooleanSchema).allowsAnyValue).isFalse()
+    }
+
+    @Test
+    fun `structurally equal schemas retain distinct identities`() {
+        val document =
+            SourceOpenApiDocumentParser.parse(
+                """
+                openapi: 3.1.2
+                info:
+                  title: Test
+                  version: "1.0"
+                paths: {}
+                components:
+                  schemas:
+                    First:
+                      type: string
+                    Second:
+                      type: string
+                """.trimIndent(),
+            )
+
+        assertThat(document.componentSchemas.getValue("First").identity)
+            .isNotEqualTo(document.componentSchemas.getValue("Second").identity)
+    }
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/GeneratorSchemaTypeClassifierTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/GeneratorSchemaTypeClassifierTest.kt
@@ -1,0 +1,168 @@
+package com.cjbooms.fabrikt.parser
+
+import com.cjbooms.fabrikt.model.OasType
+import com.cjbooms.fabrikt.model.OasType.Companion.toOasType
+import com.cjbooms.fabrikt.util.YamlUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class GeneratorSchemaTypeClassifierTest {
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "Text",
+            "Date",
+            "DateTime",
+            "Uuid",
+            "Uri",
+            "Bytes",
+            "Binary",
+            "Float",
+            "Double",
+            "Number",
+            "Int32",
+            "Int64",
+            "Integer",
+            "Boolean",
+            "Array",
+            "Set",
+            "Object",
+            "Map",
+            "Anything",
+            "Enum",
+        ],
+    )
+    fun `matches legacy classification for basic OpenAPI 3_0 schemas`(name: String) {
+        val input = openApi("3.0.4", commonSchemas)
+        val legacySchema = YamlUtils.parseOpenApi(input).schemas.getValue(name)
+        val adapted = LegacyGeneratorSchemaAdapter().adapt(legacySchema)
+
+        assertThat(GeneratorSchemaTypeClassifier.classify(adapted))
+            .isEqualTo(GeneratorSchemaTypeClassification.Resolved(legacySchema.toOasType(name), legacySchema.isNullable))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["3.0.4", "3.1.2", "3.2.0"])
+    fun `classifies basic schema types across OpenAPI versions`(version: String) {
+        val schemas = parseSchemas(version, commonSchemas)
+
+        assertResolved(schemas, "Text", OasType.Text)
+        assertResolved(schemas, "Date", OasType.Date)
+        assertResolved(schemas, "DateTime", OasType.DateTime)
+        assertResolved(schemas, "Uuid", OasType.Uuid)
+        assertResolved(schemas, "Uri", OasType.Uri)
+        assertResolved(schemas, "Bytes", OasType.Base64String)
+        assertResolved(schemas, "Binary", OasType.Binary)
+        assertResolved(schemas, "Float", OasType.Float)
+        assertResolved(schemas, "Double", OasType.Double)
+        assertResolved(schemas, "Number", OasType.Number)
+        assertResolved(schemas, "Int32", OasType.Int32)
+        assertResolved(schemas, "Int64", OasType.Int64)
+        assertResolved(schemas, "Integer", OasType.Integer)
+        assertResolved(schemas, "Boolean", OasType.Boolean)
+        assertResolved(schemas, "Array", OasType.Array)
+        assertResolved(schemas, "Set", OasType.Set)
+        assertResolved(schemas, "Object", OasType.Object)
+        assertResolved(schemas, "Map", OasType.Map)
+        assertResolved(schemas, "Anything", OasType.UntypedObject)
+        assertResolved(schemas, "Enum", OasType.Enum)
+        assertResolved(schemas, "InferredObject", OasType.Object)
+        assertResolved(schemas, "InferredArray", OasType.Array)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["3.1.2", "3.2.0"])
+    fun `classifies nullable and unsupported JSON Schema forms explicitly`(version: String) {
+        val schemas = parseSchemas(version, jsonSchemaForms)
+
+        assertThat(GeneratorSchemaTypeClassifier.classify(schemas.getValue("Nullable")))
+            .isEqualTo(GeneratorSchemaTypeClassification.Resolved(OasType.Text, true))
+        assertThat(GeneratorSchemaTypeClassifier.classify(schemas.getValue("Union")))
+            .isEqualTo(
+                GeneratorSchemaTypeClassification.Unsupported(
+                    GeneratorSchemaTypeClassification.Reason.MULTIPLE_NON_NULL_TYPES,
+                ),
+            )
+        assertThat(GeneratorSchemaTypeClassifier.classify(schemas.getValue("Never")))
+            .isEqualTo(
+                GeneratorSchemaTypeClassification.Unsupported(
+                    GeneratorSchemaTypeClassification.Reason.NEVER_SCHEMA,
+                ),
+            )
+        assertThat(GeneratorSchemaTypeClassifier.classify(schemas.getValue("Any")))
+            .isEqualTo(GeneratorSchemaTypeClassification.Resolved(OasType.Any, false))
+        assertThat(GeneratorSchemaTypeClassifier.classify(schemas.getValue("MixedComposition")))
+            .isEqualTo(
+                GeneratorSchemaTypeClassification.Unsupported(
+                    GeneratorSchemaTypeClassification.Reason.INCONSISTENT_COMPOSITION_TYPES,
+                ),
+            )
+    }
+
+    private fun assertResolved(
+        schemas: Map<String, SourceSchema>,
+        name: String,
+        expected: OasType,
+    ) {
+        assertThat(GeneratorSchemaTypeClassifier.classify(schemas.getValue(name)))
+            .isEqualTo(GeneratorSchemaTypeClassification.Resolved(expected, false))
+    }
+
+    private fun parseSchemas(
+        version: String,
+        schemas: String,
+    ): Map<String, SourceSchema> = SourceOpenApiDocumentParser.parse(openApi(version, schemas)).componentSchemas
+
+    private fun openApi(
+        version: String,
+        schemas: String,
+    ): String =
+        """
+        openapi: $version
+        info:
+          title: Test
+          version: "1.0"
+        paths: {}
+        components:
+          schemas:
+        """.trimIndent() + "\n" + schemas.prependIndent("    ")
+
+    private val commonSchemas =
+        """
+        Text: { type: string }
+        Date: { type: string, format: date }
+        DateTime: { type: string, format: date-time }
+        Uuid: { type: string, format: uuid }
+        Uri: { type: string, format: uri }
+        Bytes: { type: string, format: byte }
+        Binary: { type: string, format: binary }
+        Float: { type: number, format: float }
+        Double: { type: number, format: double }
+        Number: { type: number }
+        Int32: { type: integer, format: int32 }
+        Int64: { type: integer, format: int64 }
+        Integer: { type: integer }
+        Boolean: { type: boolean }
+        Array: { type: array, items: { type: string } }
+        Set: { type: array, uniqueItems: true, items: { type: string } }
+        Object: { type: object, properties: { value: { type: string } } }
+        Map: { type: object, additionalProperties: { type: string } }
+        Anything: { type: object }
+        Enum: { type: string, enum: [one, two] }
+        InferredObject: { properties: { value: { type: string } } }
+        InferredArray: { items: { type: string } }
+        """.trimIndent()
+
+    private val jsonSchemaForms =
+        """
+        Nullable: { type: [string, 'null'] }
+        Union: { type: [string, integer, 'null'] }
+        Never: false
+        Any: true
+        MixedComposition:
+          oneOf:
+            - { type: string }
+            - { type: integer }
+        """.trimIndent()
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/LegacyGeneratorSchemaAdapterTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/LegacyGeneratorSchemaAdapterTest.kt
@@ -1,0 +1,79 @@
+package com.cjbooms.fabrikt.parser
+
+import com.cjbooms.fabrikt.util.YamlUtils
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class LegacyGeneratorSchemaAdapterTest {
+    @Test
+    fun `adapts legacy schemas to the generator contract`() {
+        val legacySchema = YamlUtils.parseOpenApi(openApi).schemas.getValue("Subject")
+        val schema = LegacyGeneratorSchemaAdapter().adapt(legacySchema)
+
+        assertThat(schema.types).containsExactly(SourceSchemaType.OBJECT)
+        assertThat(schema.canonicalReference).endsWith("/components/schemas/Subject")
+        assertThat(schema.metadata.title).isEqualTo("Subject title")
+        assertThat(schema.metadata.description).isEqualTo("Subject description")
+        assertThat(schema.metadata.extensions).containsEntry(
+            "x-generator-hint",
+            JsonNodeFactory.instance.textNode("preserved"),
+        )
+        assertThat(schema.requiredProperties).containsExactly("value")
+        assertThat(schema.discriminator).isEqualTo(
+            SourceSchemaDiscriminator("kind", mapOf("subject" to "#/components/schemas/Subject")),
+        )
+        assertThat(schema.constraints.minimum).isEqualTo(SourceSchemaBound(BigDecimal("1.5"), true))
+        assertThat(schema.constraints.maximum).isEqualTo(SourceSchemaBound(BigDecimal("9.5"), false))
+        assertThat(schema.properties).containsOnlyKeys("kind", "value")
+        assertThat((schema.additionalProperties as GeneratorBooleanSchema).allowsAnyValue).isFalse()
+    }
+
+    @Test
+    fun `reuses adapters and identities throughout the legacy graph`() {
+        val legacySchema = YamlUtils.parseOpenApi(openApi).schemas.getValue("Subject")
+        val adapter = LegacyGeneratorSchemaAdapter()
+
+        val first = adapter.adapt(legacySchema)
+        val second = adapter.adapt(legacySchema)
+
+        assertThat(first).isSameAs(second)
+        assertThat(first.identity).isSameAs(second.identity)
+        assertThat(first.properties.getValue("value")).isSameAs(second.properties.getValue("value"))
+    }
+
+    private val openApi =
+        """
+        openapi: 3.0.4
+        info:
+          title: Test
+          version: "1.0"
+        paths: {}
+        components:
+          schemas:
+            Subject:
+              title: Subject title
+              description: Subject description
+              type: object
+              required: [value]
+              minimum: 1.5
+              exclusiveMinimum: true
+              maximum: 9.5
+              exclusiveMaximum: false
+              x-generator-hint: preserved
+              discriminator:
+                propertyName: kind
+                mapping:
+                  subject: '#/components/schemas/Subject'
+              properties:
+                kind:
+                  type: string
+                value:
+                  type: string
+                  nullable: true
+                  default: fallback
+                  enum: [first, second]
+              additionalProperties: false
+        """.trimIndent()
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/SchemaGenerationModeTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/SchemaGenerationModeTest.kt
@@ -1,0 +1,90 @@
+package com.cjbooms.fabrikt.parser
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SchemaGenerationModeTest {
+    @Test
+    fun `selects legacy schemas without reparsing the document`() {
+        val parsed = OpenApiDocumentParser.parse(openApi30)
+        val document = parsed.toGeneratorSchemaDocument(SchemaGenerationMode.LEGACY)
+
+        assertThat(document.version?.value).isEqualTo("3.0.4")
+        assertThat(document.componentSchemas).containsOnlyKeys("Subject", "Value")
+        assertThat(document.componentSchemas.values).allMatch { it is GeneratorObjectSchema && it !is SourceSchema }
+    }
+
+    @Test
+    fun `selects native schemas without passing through Kaizen`() {
+        val parsed = OpenApiDocumentParser.parse(openApi31)
+        val document = parsed.toGeneratorSchemaDocument(SchemaGenerationMode.NATIVE)
+        val value = document.componentSchemas.getValue("Value") as GeneratorObjectSchema
+
+        assertThat(document.version?.value).isEqualTo("3.1.2")
+        assertThat(document.componentSchemas.values).allMatch { it is SourceSchema }
+        assertThat(value.types).containsExactly(SourceSchemaType.STRING, SourceSchemaType.INTEGER, SourceSchemaType.NULL)
+        assertThat(GeneratorSchemaTypeClassifier.classify(value))
+            .isEqualTo(
+                GeneratorSchemaTypeClassification.Unsupported(
+                    GeneratorSchemaTypeClassification.Reason.MULTIPLE_NON_NULL_TYPES,
+                ),
+            )
+
+        val subject = document.componentSchemas.getValue("Subject") as GeneratorObjectSchema
+        assertThat(document.resolve(subject.properties.getValue("value"))).isSameAs(value)
+    }
+
+    @Test
+    fun `legacy and native modes classify basic OpenAPI 3_0 schemas equally`() {
+        val parsed = OpenApiDocumentParser.parse(openApi30)
+        val legacy = parsed.toGeneratorSchemaDocument(SchemaGenerationMode.LEGACY)
+        val native = parsed.toGeneratorSchemaDocument(SchemaGenerationMode.NATIVE)
+
+        assertThat(legacy.componentSchemas.keys).containsExactlyInAnyOrderElementsOf(native.componentSchemas.keys)
+        legacy.componentSchemas.keys.forEach { name ->
+            assertThat(GeneratorSchemaTypeClassifier.classify(legacy.componentSchemas.getValue(name)))
+                .isEqualTo(GeneratorSchemaTypeClassifier.classify(native.componentSchemas.getValue(name)))
+        }
+
+        val legacySubject = legacy.componentSchemas.getValue("Subject") as GeneratorObjectSchema
+        assertThat(legacy.resolve(legacySubject.properties.getValue("value")))
+            .isSameAs(legacySubject.properties.getValue("value"))
+    }
+
+    private val openApi30 =
+        """
+        openapi: 3.0.4
+        info:
+          title: Test
+          version: "1.0"
+        paths: {}
+        components:
+          schemas:
+            Subject:
+              type: object
+              properties:
+                value:
+                  ${'$'}ref: '#/components/schemas/Value'
+            Value:
+              type: string
+              nullable: true
+        """.trimIndent()
+
+    private val openApi31 =
+        """
+        openapi: 3.1.2
+        info:
+          title: Test
+          version: "1.0"
+        paths: {}
+        components:
+          schemas:
+            Subject:
+              type: object
+              properties:
+                value:
+                  ${'$'}ref: '#/components/schemas/Value'
+            Value:
+              type: [string, integer, 'null']
+        """.trimIndent()
+}

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaSemanticsTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaSemanticsTest.kt
@@ -53,6 +53,10 @@ class SourceSchemaSemanticsTest {
         assertThat(schema.metadata.readOnly).isTrue()
         assertThat(schema.metadata.writeOnly).isTrue()
         assertThat(schema.metadata.deprecated).isTrue()
+        assertThat(schema.metadata.extensions).containsEntry(
+            "x-generator-hint",
+            JsonNodeFactory.instance.textNode("preserved"),
+        )
         assertThat(schema.requiredProperties).containsExactly("first", "second")
         assertThat(schema.discriminator).isEqualTo(
             SourceSchemaDiscriminator("kind", mapOf("cat" to "#/components/schemas/Cat")),
@@ -97,6 +101,7 @@ class SourceSchemaSemanticsTest {
         readOnly: true
         writeOnly: true
         deprecated: true
+        x-generator-hint: preserved
         required: [first, second]
         discriminator:
           propertyName: kind

--- a/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaSemanticsTest.kt
+++ b/src/test/kotlin/com/cjbooms/fabrikt/parser/SourceSchemaSemanticsTest.kt
@@ -1,0 +1,149 @@
+package com.cjbooms.fabrikt.parser
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.math.BigDecimal
+
+class SourceSchemaSemanticsTest {
+    @Test
+    fun `normalizes OpenAPI 3_0 schema semantics`() {
+        val schema = parseSchema("3.0.4", openApi30Schema) as SourceObjectSchema
+
+        assertCommonSemantics(schema)
+        assertThat(schema.types).containsExactly(SourceSchemaType.STRING, SourceSchemaType.NULL)
+        assertThat(schema.metadata.examples).containsExactly(JsonNodeFactory.instance.textNode("legacy example"))
+        assertThat(schema.constraints.minimum).isEqualTo(SourceSchemaBound(BigDecimal("1.5"), true))
+        assertThat(schema.constraints.maximum).isEqualTo(SourceSchemaBound(BigDecimal("9.5"), false))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["3.1.2", "3.2.0"])
+    fun `normalizes JSON Schema 2020-12 semantics`(version: String) {
+        val schema = parseSchema(version, jsonSchema202012) as SourceObjectSchema
+
+        assertCommonSemantics(schema)
+        assertThat(schema.types).containsExactly(SourceSchemaType.STRING, SourceSchemaType.NULL)
+        assertThat(schema.metadata.examples).containsExactly(
+            JsonNodeFactory.instance.textNode("first"),
+            JsonNodeFactory.instance.textNode("second"),
+        )
+        assertThat(schema.constraints.minimum).isEqualTo(SourceSchemaBound(BigDecimal("2.5"), true))
+        assertThat(schema.constraints.maximum).isEqualTo(SourceSchemaBound(BigDecimal("8.5"), true))
+        assertThat(schema.constraints.minContains).isEqualTo(1)
+        assertThat(schema.constraints.maxContains).isEqualTo(2)
+        assertThat(schema.metadata.constValue).isEqualTo(JsonNodeFactory.instance.textNode("first"))
+        assertThat(schema.metadata.contentEncoding).isEqualTo("base64")
+        assertThat(schema.metadata.contentMediaType).isEqualTo("application/octet-stream")
+        assertThat(schema.dependentRequired).containsEntry("first", linkedSetOf("second", "third"))
+    }
+
+    private fun assertCommonSemantics(schema: SourceObjectSchema) {
+        assertThat(schema.metadata.title).isEqualTo("A title")
+        assertThat(schema.metadata.description).isEqualTo("A description")
+        assertThat(schema.metadata.format).isEqualTo("custom")
+        assertThat(schema.metadata.defaultValue).isEqualTo(JsonNodeFactory.instance.textNode("default value"))
+        assertThat(schema.metadata.enumValues).containsExactly(
+            JsonNodeFactory.instance.textNode("first"),
+            JsonNodeFactory.instance.numberNode(2),
+            JsonNodeFactory.instance.nullNode(),
+        )
+        assertThat(schema.metadata.readOnly).isTrue()
+        assertThat(schema.metadata.writeOnly).isTrue()
+        assertThat(schema.metadata.deprecated).isTrue()
+        assertThat(schema.requiredProperties).containsExactly("first", "second")
+        assertThat(schema.discriminator).isEqualTo(
+            SourceSchemaDiscriminator("kind", mapOf("cat" to "#/components/schemas/Cat")),
+        )
+        assertThat(schema.constraints.multipleOf).isEqualByComparingTo("0.5")
+        assertThat(schema.constraints.minLength).isEqualTo(2)
+        assertThat(schema.constraints.maxLength).isEqualTo(20)
+        assertThat(schema.constraints.pattern).isEqualTo("^[a-z]+$")
+        assertThat(schema.constraints.minItems).isEqualTo(1)
+        assertThat(schema.constraints.maxItems).isEqualTo(5)
+        assertThat(schema.constraints.uniqueItems).isTrue()
+        assertThat(schema.constraints.minProperties).isEqualTo(1)
+        assertThat(schema.constraints.maxProperties).isEqualTo(4)
+    }
+
+    private fun parseSchema(
+        version: String,
+        schema: String,
+    ): SourceSchema {
+        val document =
+            """
+            openapi: $version
+            info:
+              title: Test
+              version: "1.0"
+            paths: {}
+            components:
+              schemas:
+                Subject:
+            """.trimIndent() + "\n" + schema.prependIndent("      ")
+
+        return SourceOpenApiDocumentParser.parse(document).componentSchemas.getValue("Subject")
+    }
+
+    private val commonSchema =
+        """
+        title: A title
+        description: A description
+        format: custom
+        default: default value
+        enum: [first, 2, null]
+        readOnly: true
+        writeOnly: true
+        deprecated: true
+        required: [first, second]
+        discriminator:
+          propertyName: kind
+          mapping:
+            cat: '#/components/schemas/Cat'
+        multipleOf: 0.5
+        minLength: 2
+        maxLength: 20
+        pattern: '^[a-z]+$'
+        minItems: 1
+        maxItems: 5
+        uniqueItems: true
+        minProperties: 1
+        maxProperties: 4
+        """.trimIndent()
+
+    private val openApi30Schema =
+        listOf(
+            """
+            type: string
+            nullable: true
+            example: legacy example
+            minimum: 1.5
+            exclusiveMinimum: true
+            maximum: 9.5
+            exclusiveMaximum: false
+            """.trimIndent(),
+            commonSchema,
+        ).joinToString("\n")
+
+    private val jsonSchema202012 =
+        listOf(
+            """
+            type: [string, 'null']
+            examples: [first, second]
+            minimum: 1.5
+            exclusiveMinimum: 2.5
+            maximum: 9.5
+            exclusiveMaximum: 8.5
+            minContains: 1
+            maxContains: 2
+            contentEncoding: base64
+            contentMediaType: application/octet-stream
+            const: first
+            dependentRequired:
+              first: [second, third]
+            """.trimIndent(),
+            commonSchema,
+        ).joinToString("\n")
+}


### PR DESCRIPTION
## Summary

This PR introduces the first cohesive foundation for the native OpenAPI generation path discussed in #656.

It:

- models normalized, version-aware source schema semantics;
- introduces generator-facing schema contracts that do not depend on Kaizen types;
- adapts the existing Kaizen-backed schemas to those shared contracts;
- adds native schema type classification for OpenAPI 3.0, 3.1, and 3.2 semantics;
- introduces internal selection between legacy and native schema documents.

The existing Kaizen-backed path remains the default. The native mode is deliberately internal at this stage and is not exposed as a public CLI option yet.

## Motivation

The current generators consume Kaizen-specific schema types directly, which makes incremental support for modern OpenAPI and JSON Schema semantics difficult.

The new contracts establish a boundary between parsing and generation. This allows the existing implementation to continue through the legacy adapter while later PRs can build a Fabrikt-owned native representation behind the same generator-facing interface.

This is the first of the grouped follow-up PRs described in #673. It is intentionally limited to the schema boundary and classification foundation; model, endpoint, server, and client generation remain separate follow-up changes.

## Compatibility

- Existing generated output remains unchanged.
- `LEGACY` remains the effective default.
- No new public CLI option is introduced.
- No existing golden files are modified.

## Testing

- Added focused tests for normalized schema semantics.
- Added contract and legacy-adapter tests.
- Added native type-classification tests.
- Added OpenAPI 3.0, 3.1, and 3.2 schema-document selection coverage.
- The full project build, including end-to-end projects and generated-output checks, is used for final verification.

Part of #656.